### PR TITLE
workflows: remove frozen tag from cargo test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         name: cargo test
         with:
           command: test
-          args: --all-targets --benches --frozen
+          args: --all-targets --benches
       - uses: actions-rs/cargo@v1
         name: cargo fmt
         with:


### PR DESCRIPTION
Seeing build failures blaming `--frozen`, removing to see whether this will resolve things. 
```
Run actions-rs/cargo@v1
/home/runner/.cargo/bin/cargo test --all-targets --benches --frozen
error: failed to download `aho-corasick v0.7.20`
Error: failed to download `aho-corasick v0.7.20`
Caused by:
  attempting to make an HTTP request, but --frozen was specified
Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
```


As seen in [build failure](https://github.com/carlaKC/lndk/actions/runs/4533196591/jobs/7985683191?pr=20).