### PR TITLE
tests: move test lnd logs to a more permanent location

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,18 @@ jobs:
         with:
           command: test
           args: --all-targets --benches -- --test-threads=1
+      - name: Archive lnd logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: lnd-logs
+          path: |
+            /tmp/lnd_logs
+      - name: Archive ldk logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: ldk-logs
+          path: |
+            /tmp/ldk_logs
       - uses: actions-rs/cargo@v1
         name: cargo fmt
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,8 +1079,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 [[package]]
 name = "ldk-node"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac8e08ff2fac5bf806d260d981bf671bc78b2b7df3d06e3c8ce091286b9d68b"
+source = "git+https://github.com/lightningdevkit/ldk-node?rev=3a31209#3a31209f83f1c51b3ab5bedfc3633e81a9418e0f"
 dependencies = [
  "bdk",
  "bip39",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,6 +1224,7 @@ dependencies = [
  "bitcoin 0.29.2",
  "bitcoind 0.30.0",
  "bytes",
+ "chrono",
  "configure_me",
  "configure_me_codegen",
  "core-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ bytes = "1.4.0"
 [dev-dependencies]
 bitcoincore-rpc = { package="core-rpc", version = "0.17.0" }
 bitcoind = { version = "0.30.0", features = [ "22_0" ] }
+chrono = { version = "0.4.26" }
 electrsd = { version = "0.22.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_23_0"] }
 flate2 = "1.0.25"
 ldk-node = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ bitcoind = { version = "0.30.0", features = [ "22_0" ] }
 chrono = { version = "0.4.26" }
 electrsd = { version = "0.22.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_23_0"] }
 flate2 = "1.0.25"
-ldk-node = "0.1.0"
+ldk-node = { git = "https://github.com/lightningdevkit/ldk-node", rev = "3a31209" }
 minreq = { version = "2.7.0", features = [ "https" ] }
 mockall = "0.11.3"
 tar = "0.4.38"

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,7 +2,9 @@ mod common;
 
 #[tokio::test]
 async fn test_setup() {
+    let test_name = String::from("test_setup");
+
     // Spin up a bitcoind and lnd node, which are required for our tests.
     let (_bitcoind, _lnd, _bitcoind_dir, _electrsd, _ldk_node, _ldk_dir) =
-        common::setup_test_infrastructure().await;
+        common::setup_test_infrastructure(test_name).await;
 }


### PR DESCRIPTION
Here's a first stab at drafting a solution for storing logs, as discussed with @carlaKC  in #58 . The code changes are pretty small, but a couple notes below on implementation, including a change to LDK that we need to do to get this fully working.

A couple of notes on implementation:
- I went with storing the LND logs in a custom /tmp directory for each test. The motivation being that this keeps the logs around after the test so developers can use it for debugging, but since the logs likely won't be needed for long, it's nice to have them stored in the /tmp file so that they're automatically deleted by the OS after a certain amount of time/when the device restarts.
- It's possible to specify a custom path for LND logs. But this is not supported by LDK quite yet. Should be easy to add support, I'm pinging Elias from LDK about doing a quick PR for this, if that sounds good. Then we can finish up the LDK side of things.