### PR TITLE
README: Add discord invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Project Milestones:
 * [Code of Conduct](https://github.com/lndk-org/lndk/blob/master/code_of_conduct.md)
 * [Architecture](https://github.com/lndk-org/lndk/blob/master/ARCH.md)
 
+When you encounter a problem with `LNDK`, Feel free to file issues or start [a discussion](https://github.com/lndk-org/lndk/discussions). If your question doesn't fit in either place, find us in the [BOLT 12 Discord](https://discord.gg/Pk7mT3FQFn) in the lndk channel.
+
 ## Setting up LNDK
 
 #### Compiling LND


### PR DESCRIPTION
Just a little PR to make note of where people can ask us questions about lndk. However, I was reading about how discord invite links are impermanent unless you have a particular type of discord server, so emailing us directly might be the best route for discord invites? Thoughts?

If anyone else wants to add their email to the list lmk. Otherwise I'm happy to be the invitation handler. 