### PR TITLE
offers: wait for offers invoice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 [[package]]
 name = "ldk-sample"
 version = "0.1.0"
-source = "git+https://github.com/lndk-org/ldk-sample?branch=offers#848e562f0ef57c95e015454cc2c00bca1e315e29"
+source = "git+https://github.com/lndk-org/ldk-sample?branch=offer-handling#cdc1b006694eb323a8a982d523ae5b40f5f857ad"
 dependencies = [
  "base64 0.13.1",
  "bech32 0.8.1",
@@ -1095,6 +1095,7 @@ dependencies = [
  "rand_core 0.6.4",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tonic 0.8.3",
  "tonic_lnd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rand_core = "0.6.4"
 log = "0.4.17"
 log4rs = { version = "1.2.0", features = ["file_appender"] }
 tokio = { version = "1.25.0", features = ["rt", "rt-multi-thread"] }
+tokio-stream = { version = "0.1.14" }
 tonic = "0.8.3"
 tonic_lnd = { git = "https://github.com/orbitalturtle/tonic_lnd", branch = "update-signer-client" }
 hex = "0.4.3"
@@ -34,7 +35,7 @@ bytes = "1.4.0"
 bitcoincore-rpc = { package="core-rpc", version = "0.17.0" }
 bitcoind = { version = "0.30.0", features = [ "22_0" ] }
 chrono = { version = "0.4.26" }
-ldk-sample = { git = "https://github.com/lndk-org/ldk-sample", branch = "offers" }
+ldk-sample = { git = "https://github.com/lndk-org/ldk-sample", branch = "offer-handling" }
 mockall = "0.11.3"
 tempfile = "3.5.0"
 

--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,5 @@ itest:
 	@$(call print, "Building lnd for itests.")
 	git submodule update --init --recursive
 	cd lnd/cmd/lnd; $(GO_BUILD) -tags="peersrpc signrpc walletrpc dev" -o $(TMP_DIR)/lndk-tests/bin/lnd-itest$(EXEC_SUFFIX)
-	$(CARGO_TEST) -- -- test '*' --test-threads=1 --nocapture
+	$(CARGO_TEST) --test '*' -- --test-threads=1 --nocapture
 

--- a/src/lnd.rs
+++ b/src/lnd.rs
@@ -53,14 +53,14 @@ pub(crate) fn features_support_onion_messages(
 }
 
 /// LndNodeSigner provides signing operations using LND's signer subserver.
-pub(crate) struct LndNodeSigner<'a> {
+pub struct LndNodeSigner<'a> {
     pubkey: PublicKey,
     secp_ctx: Secp256k1<secp256k1::All>,
     signer: RefCell<&'a mut tonic_lnd::SignerClient>,
 }
 
 impl<'a> LndNodeSigner<'a> {
-    pub(crate) fn new(pubkey: PublicKey, signer: &'a mut tonic_lnd::SignerClient) -> Self {
+    pub fn new(pubkey: PublicKey, signer: &'a mut tonic_lnd::SignerClient) -> Self {
         LndNodeSigner {
             pubkey,
             secp_ctx: Secp256k1::new(),

--- a/src/onion_messenger.rs
+++ b/src/onion_messenger.rs
@@ -51,12 +51,12 @@ const DEFAULT_CALL_FREQUENCY: Duration = Duration::from_secs(1);
 /// A refcell is used for entropy_source to provide interior mutability for ChaCha20Rng. We need a mutable reference
 /// to be able to use the chacha library’s fill_bytes method, but the EntropySource interface in LDK is for an
 /// immutable reference.
-pub(crate) struct MessengerUtilities {
+pub struct MessengerUtilities {
     entropy_source: RefCell<ChaCha20Rng>,
 }
 
 impl MessengerUtilities {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         MessengerUtilities {
             entropy_source: RefCell::new(ChaCha20Rng::from_entropy()),
         }

--- a/src/onion_messenger.rs
+++ b/src/onion_messenger.rs
@@ -66,6 +66,12 @@ impl MessengerUtilities {
     }
 }
 
+impl Default for MessengerUtilities {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl EntropySource for MessengerUtilities {
     // TODO: surface LDK's EntropySource and use instead.
     fn get_secure_random_bytes(&self) -> [u8; 32] {

--- a/tests/common/test_utils.rs
+++ b/tests/common/test_utils.rs
@@ -19,11 +19,11 @@ where
     while retry_num < 3 {
         sleep(Duration::from_secs(3)).await;
         match f().await {
-            Err(_) => {
+            Err(e) => {
                 println!("retrying {} call", func_name.clone());
                 retry_num += 1;
                 if retry_num == 5 {
-                    panic!("{} call failed after 3 retries", func_name);
+                    panic!("{} call failed after 3 retries: {:?}", func_name, e);
                 }
                 continue;
             }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3,21 +3,24 @@ use lndk;
 
 use bitcoin::secp256k1::{PublicKey, Secp256k1};
 use bitcoin::Network;
+use bitcoincore_rpc::bitcoin::Network as RpcNetwork;
+use bitcoincore_rpc::RpcApi;
 use ldk_sample::node_api::Node as LdkNode;
 use lightning::blinded_path::BlindedPath;
 use lightning::ln::peer_handler::IgnoringMessageHandler;
 use lightning::offers::offer::Quantity;
 use lightning::onion_message::{DefaultMessageRouter, OnionMessenger};
 use lndk::lnd::LndNodeSigner;
-use lndk::lndk_offers::request_invoice;
+use lndk::lndk_offers::{request_invoice, wait_for_invoice};
 use lndk::onion_messenger::{CustomMessenger, InvoiceHandler, MessengerUtilities};
 use std::collections::VecDeque;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
-use tokio::select;
 use tokio::time::{sleep, timeout, Duration as TokioDuration};
+use tokio::{join, select};
 
 async fn wait_to_receive_onion_message(
     ldk1: LdkNode,
@@ -184,4 +187,148 @@ async fn test_lndk_send_invoice_request() {
             ldk2.stop().await;
         }
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+// Here we test that when the offer creator responds with an invoice, lndk is able to receive it.
+async fn test_lndk_wait_for_invoice() {
+    let test_name = "lndk_wait_for_invoice";
+    let (bitcoind, mut lnd, ldk1, ldk2, _lndk_dir) =
+        common::setup_test_infrastructure(test_name).await;
+
+    // Here we'll produce a little network of channels:
+    //
+    // ldk1 <- ldk2 <- lnd
+    //
+    // ldk1 will be the offer creator, which will build a blinded route from ldk2 to ldk1.
+    let (pubkey, addr) = ldk1.get_node_info();
+    let (pubkey_2, addr_2) = ldk2.get_node_info();
+
+    ldk1.connect_to_peer(pubkey_2, addr_2).await.unwrap();
+    lnd.connect_to_peer(pubkey_2, addr_2).await;
+
+    let lnd_info = lnd.get_info().await;
+    let lnd_pubkey = PublicKey::from_str(&lnd_info.identity_pubkey).unwrap();
+
+    // ldk1 won't send back the invoice unless we have channels in our network.
+    let ldk2_fund_addr = ldk2.bitcoind_client.get_new_address().await;
+    let lnd_fund_addr = lnd.new_address().await.address;
+
+    // We need to convert funding addresses to the form that the bitcoincore_rpc library recognizes.
+    let ldk2_addr_string = ldk2_fund_addr.to_string();
+    let ldk2_addr = bitcoincore_rpc::bitcoin::Address::from_str(&ldk2_addr_string)
+        .unwrap()
+        .require_network(RpcNetwork::Regtest)
+        .unwrap();
+    let lnd_addr = bitcoincore_rpc::bitcoin::Address::from_str(&lnd_fund_addr)
+        .unwrap()
+        .require_network(RpcNetwork::Regtest)
+        .unwrap();
+    let lnd_network_addr = lnd
+        .address
+        .replace("localhost", "127.0.0.1")
+        .replace("https://", "");
+
+    // Fund both of these nodes so we can open channels.
+    bitcoind
+        .node
+        .client
+        .generate_to_address(1, &ldk2_addr)
+        .unwrap();
+    bitcoind
+        .node
+        .client
+        .generate_to_address(1, &lnd_addr)
+        .unwrap();
+
+    // Make sure the above funds are confirmed.
+    bitcoind
+        .node
+        .client
+        .generate_to_address(100, &ldk2_addr)
+        .unwrap();
+
+    ldk2.open_channel(pubkey, addr, 200000, 0, true)
+        .await
+        .unwrap();
+    ldk2.open_channel(
+        lnd_pubkey,
+        SocketAddr::from_str(&lnd_network_addr).unwrap(),
+        200000,
+        100000,
+        false,
+    )
+    .await
+    .unwrap();
+
+    bitcoind
+        .node
+        .client
+        .generate_to_address(100, &ldk2_addr)
+        .unwrap();
+
+    // TODO: Restarting the lnd node here isn't ideal. But for some reason after we call LDK's open_channel
+    // API call, LND blocks and is unable to receive any API requests. This might be a bug in ldk-sample or
+    // our ldk-sample implementation.
+    lnd.handle.kill().expect("lnd couldn't be killed");
+    lnd.start().await;
+    lnd.connect_to_peer(pubkey_2, addr_2).await;
+
+    let path_pubkeys = vec![pubkey_2, pubkey];
+    let expiration = SystemTime::now() + Duration::from_secs(24 * 60 * 60);
+    let offer = ldk1
+        .create_offer(
+            &path_pubkeys,
+            Network::Regtest,
+            20_000,
+            Quantity::One,
+            expiration,
+        )
+        .await
+        .expect("should create offer");
+
+    let mut signer_clone = lnd.client.clone().unwrap();
+    let signer_client = signer_clone.signer();
+    let node_signer = LndNodeSigner::new(lnd_pubkey.clone(), signer_client);
+    let messenger_utils = MessengerUtilities::new();
+    let mut invoice_handler = InvoiceHandler {
+        invoices: Arc::new(Mutex::new(VecDeque::new())),
+    };
+    let onion_messenger = OnionMessenger::new(
+        &messenger_utils,
+        &node_signer,
+        &messenger_utils,
+        &DefaultMessageRouter {},
+        &mut invoice_handler,
+        IgnoringMessageHandler {},
+    );
+
+    let client = lnd.client.clone().unwrap();
+    let mut client_clone = lnd.client.clone().unwrap();
+    let custom_msg_client = CustomMessenger {
+        client: client_clone.lightning().to_owned(),
+    };
+    let blinded_path = offer.paths()[0].clone();
+    let secp_ctx = Secp256k1::new();
+    let reply_path =
+        BlindedPath::new_for_message(&[pubkey_2, lnd_pubkey], &messenger_utils, &secp_ctx).unwrap();
+
+    let (res1, res2) = join!(
+        wait_for_invoice(client_clone.lightning(), &onion_messenger),
+        request_invoice(
+            client.clone(),
+            &onion_messenger,
+            custom_msg_client,
+            offer,
+            pubkey_2,
+            reply_path,
+            blinded_path
+        )
+    );
+    res1.unwrap();
+    res2.unwrap();
+
+    // LND should have received the Bolt12Invoice.
+    let invoices = invoice_handler.invoices.lock().unwrap();
+    assert!(invoices.len() == 1);
 }


### PR DESCRIPTION
This PR implements the next part of the offers flow, as described in #64. 

After sending an invoice request to the offer creator, we wait for an invoice to be returned.

It depends on #81 and the changes in https://github.com/lndk-org/ldk-sample/pull/8