### PR TITLE
Logging fixes

### DIFF
--- a/config_spec.toml
+++ b/config_spec.toml
@@ -25,3 +25,9 @@ doc = "The path to LND macaroon file. Note: the abosolute macaroon file path is 
 name = "log_dir"
 type = "String"
 doc = "The path to the lndk log file"
+
+[[param]]
+name = "log_level"
+type = "String"
+optional = true
+doc = "The log verbosity level. This can be set to either 'error', 'warn', 'info', 'debug' or 'trace'."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ static INIT: Once = Once::new();
 pub struct Cfg {
     pub lnd: LndCfg,
     pub log_dir: Option<String>,
+    pub log_level: LevelFilter,
     pub signals: LifecycleSignals,
 }
 
@@ -102,7 +103,7 @@ impl LndkOnionMessenger {
                 Root::builder()
                     .appender("stdout")
                     .appender("lndk_logs")
-                    .build(LevelFilter::Info),
+                    .build(args.log_level),
             )
             .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ use lightning::sign::{EntropySource, KeyMaterial};
 use log::{error, info, LevelFilter};
 use log4rs::append::console::ConsoleAppender;
 use log4rs::append::file::FileAppender;
-use log4rs::config::{Appender, Config as LogConfig, Root};
+use log4rs::config::{Appender, Config as LogConfig, Logger, Root};
 use log4rs::encode::pattern::PatternEncoder;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -93,6 +93,11 @@ impl LndkOnionMessenger {
         let config = LogConfig::builder()
             .appender(Appender::builder().build("stdout", Box::new(stdout)))
             .appender(Appender::builder().build("lndk_logs", Box::new(lndk_logs)))
+            .logger(Logger::builder().build("h2", LevelFilter::Info))
+            .logger(Logger::builder().build("hyper", LevelFilter::Info))
+            .logger(Logger::builder().build("rustls", LevelFilter::Info))
+            .logger(Logger::builder().build("tokio_util", LevelFilter::Info))
+            .logger(Logger::builder().build("tracing", LevelFilter::Info))
             .build(
                 Root::builder()
                     .appender("stdout")

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,8 @@ mod internal {
 use internal::*;
 use lndk::lnd::LndCfg;
 use lndk::{Cfg, LifecycleSignals, LndkOnionMessenger, OfferHandler};
+use log::LevelFilter;
+use std::str::FromStr;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::{Receiver, Sender};
 
@@ -25,6 +27,21 @@ async fn main() -> Result<(), ()> {
         .0;
 
     let lnd_args = LndCfg::new(config.address, config.cert, config.macaroon);
+    let log_level = match config.log_level {
+        Some(level_str) => match LevelFilter::from_str(&level_str) {
+            Ok(level) => level,
+            Err(_) => {
+                // Since the logger isn't set up yet, we use a println just this once.
+                println!(
+                    "User provided log level '{}' is invalid. Make sure it is set to either 'error',
+                    'warn', 'info', 'debug' or 'trace'",
+                    level_str
+                );
+                return Err(());
+            }
+        },
+        None => LevelFilter::Info,
+    };
     let (shutdown, listener) = triggered::trigger();
     // Create the channel which will tell us when the onion messenger has finished starting up.
     let (tx, _): (Sender<u32>, Receiver<u32>) = mpsc::channel(1);
@@ -36,6 +53,7 @@ async fn main() -> Result<(), ()> {
     let args = Cfg {
         lnd: lnd_args,
         log_dir: config.log_dir,
+        log_level,
         signals,
     };
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -12,6 +12,7 @@ use lightning::offers::offer::Quantity;
 use lightning::onion_message::messenger::Destination;
 use lndk::onion_messenger::MessengerUtilities;
 use lndk::{LifecycleSignals, PayOfferParams};
+use log::LevelFilter;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -93,6 +94,7 @@ async fn test_lndk_forwards_onion_message() {
                 .unwrap()
                 .to_string(),
         ),
+        log_level: LevelFilter::Info,
         signals,
     };
 
@@ -205,6 +207,7 @@ async fn test_lndk_send_invoice_request() {
                 .unwrap()
                 .to_string(),
         ),
+        log_level: LevelFilter::Info,
         signals,
     };
 
@@ -279,6 +282,7 @@ async fn test_lndk_send_invoice_request() {
                 .unwrap()
                 .to_string(),
         ),
+        log_level: LevelFilter::Info,
         signals,
     };
 
@@ -407,6 +411,7 @@ async fn test_lndk_pay_offer() {
                 .unwrap()
                 .to_string(),
         ),
+        log_level: LevelFilter::Info,
         signals,
     };
 


### PR DESCRIPTION
Whoops @carlaKC, the original PR, I had it pointing toward #91 instead of master, so we merged it to the wrong place. My bad!

This PR is the same but just one other small change: Now uses println! instead of error! to print the log setup error. If we use error!, this doesn't show up for the user because the logger isn't set up yet.