### PR TITLE
Add missing fee ppm parameter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,6 +253,7 @@ impl OfferHandler {
             path: path_info.1,
             cltv_expiry_delta: path_info.0.cltv_expiry_delta,
             fee_base_msat: path_info.0.fee_base_msat,
+            fee_ppm: path_info.0.fee_proportional_millionths,
             payment_hash: payment_hash.0,
             msats: validated_amount,
             offer_id,

--- a/src/lnd.rs
+++ b/src/lnd.rs
@@ -220,6 +220,7 @@ pub trait InvoicePayer {
         path: BlindedPath,
         cltv_expiry_delta: u16,
         fee_base_msat: u32,
+        fee_ppm: u32,
         msats: u64,
     ) -> Result<QueryRoutesResponse, Status>;
     async fn send_to_route(


### PR DESCRIPTION
Sets the ppm_fee parameter when querying for a route. My bad for not setting this originally. If not set, this can lead to an offer payment error, because the full fee isn't taken into account.