### PR TITLE
Setup grpc server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,13 +586,13 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "prost 0.12.3",
+ "prost",
  "rustls",
  "rustls-pemfile",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
- "tonic-build",
+ "tonic-build 0.10.2",
  "tower",
 ]
 
@@ -1167,11 +1167,13 @@ dependencies = [
  "log",
  "log4rs",
  "mockall",
+ "prost",
  "rand_chacha",
  "rand_core 0.6.4",
  "tempfile",
  "tokio",
- "tonic 0.8.3",
+ "tonic 0.11.0",
+ "tonic-build 0.11.0",
  "triggered",
 ]
 
@@ -1516,22 +1518,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive 0.11.9",
-]
-
-[[package]]
-name = "prost"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
  "bytes",
- "prost-derive 0.12.3",
+ "prost-derive",
 ]
 
 [[package]]
@@ -1548,25 +1540,12 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.12.3",
+ "prost",
  "prost-types",
  "regex",
  "syn 2.0.48",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1588,7 +1567,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
 dependencies = [
- "prost 0.12.3",
+ "prost",
 ]
 
 [[package]]
@@ -2115,38 +2094,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.13.1",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.11.9",
- "prost-derive 0.11.9",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "tonic"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
@@ -2163,7 +2110,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.12.3",
+ "prost",
  "rustls",
  "rustls-pemfile",
  "tokio",
@@ -2176,10 +2123,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.7",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tonic-build"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2250,16 +2237,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,13 @@ rand_core = "0.6.4"
 log = "0.4.17"
 log4rs = { version = "1.2.0", features = ["file_appender"] }
 tokio = { version = "1.25.0", features = ["rt", "rt-multi-thread"] }
-tonic = "0.8.3"
+tonic = "0.11"
 tonic_lnd = { git = "https://github.com/orbitalturtle/tonic_lnd", rev="afb0187621bca604f606cacfe3cb2aedf5d2fc89", package="fedimint-tonic-lnd", features = ["lightningrpc", "routerrpc"] }
 hex = "0.4.3"
 configure_me = "0.4.0"
 bytes = "1.4.0"
 triggered = "0.1.2"
+prost = "0.12"
 
 [dev-dependencies]
 bitcoincore-rpc = { package="core-rpc", version = "0.17.0" }
@@ -41,6 +42,7 @@ tempfile = "3.5.0"
 
 [build-dependencies]
 configure_me_codegen = "0.4.4"
+tonic-build = "0.11"
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ LNDK is a standalone daemon that connects to [LND](https://github.com/lightningn
 
 Project Milestones:
 - [x] [v0.1.0](https://github.com/lndk-org/lndk/milestone/1): Onion message forwarding for LND.
-- [ ] [v0.2.0](https://github.com/lndk-org/lndk/milestone/2): Payment to offers with blinded paths.
+- [x] [v0.2.0](https://github.com/lndk-org/lndk/milestone/2): Payment to offers with blinded paths.
 
 *Please note that this project is still experimental.*
 
@@ -52,7 +52,8 @@ Now that we have LND set up properly, there are two key things you can do with L
 1) Forward onion messages. By increasing the number of Lightning nodes out there that can forward onion messages, this increases the anonymity set and helps to bootstrap BOLT 12 for more private payments.
 2) Pay BOLT 12 offers, a more private standard for receiving payments over Lightning, which also allows for static invoices.
 
-To accomplish #1, follow the instructions below to get the LNDK binary up and running. For #2, you can [use the CLI](https://github.com/lndk-org/lndk/blob/master/docs/cli_commands.md).
+To accomplish #1, follow the instructions below to get the LNDK binary up and running. Once you have LNDK up and running, you can accomplish #2
+[here](https://github.com/lndk-org/lndk/blob/master/docs/cli_commands.md) with either `lndk-cli` or setting up your own gRPC client.
 
 #### Running LNDK
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,10 @@
-fn main() {
-    configure_me_codegen::build_script_auto().unwrap_or_else(|error| error.report_and_exit())
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    configure_me_codegen::build_script_auto().unwrap_or_else(|error| error.report_and_exit());
+
+    // Compile the protos for our grpc server.
+    tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .compile(&["proto/lndkrpc.proto"], &["proto"])?;
+
+    Ok(())
 }

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -44,3 +44,15 @@ name = "log_level"
 type = "String"
 optional = true
 doc = "The log verbosity level. This can be set to either 'error', 'warn', 'info', 'debug' or 'trace'."
+
+[[param]]
+name = "grpc_host"
+type = "String"
+optional = true
+doc = "The host the grpc server will run on. Defaults to 127.0.0.1."
+
+[[param]]
+name = "grpc_port"
+type = "u16"
+optional = true
+doc = "The port the grpc server will run on. Defaults to 7000."

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -1,8 +1,10 @@
-# LNDK-CLI
+# Interacting with LNDK server
 
-For now, you can use `lndk-cli` separately from `lndk` meaning you don't need to have a `lndk` binary running for `lndk-cli` to work.
+There are two ways you can connect to the server:
+- You can use `lndk-cli` to connect to a running instance of `LNDK` and pay an offer.
+- Write a gRPC client in the language of your choice.
 
-## Installation
+## lndk-cli installation
 
 To use the `lndk-cli` to pay a BOLT 12 offer, follow these instructions:
 - To install lndk-cli: 
@@ -21,30 +23,35 @@ Commands:
   help       Print this message or the help of the given subcommand(s)
 
 Options:
-  -n, --network <NETWORK>              Global variables [default: regtest]
-  -c, --cert-path <CERT_PATH>          
-  -m, --macaroon-path <MACAROON_PATH>  
-      --cert-pem <CERT_PEM>            
+  -n, --network <NETWORK>              Global variables [default: regtest]          
+  -m, --macaroon-path <MACAROON_PATH>           
       --macaroon-hex <MACAROON_HEX>    
-  -a, --address <ADDRESS>              [default: https://localhost:10009]
   -h, --help                           Print help
 ```
 
-## Commands 
+### lndk-cli commands
 
 Once `lndk-cli` is installed, you can use it to pay an offer.
 
-Since `lndk-cli` needs to connect to lnd, you'll need to provide lnd credentials to the binary. 
+Since `lndk-cli` needs to connect to lnd, you'll need to provide an lnd macaroon to the binary. 
 
-If your credentials are not in the default location, you'll need to specify them manually.
+If your macaroon is not in the default lnd location, you'll need to specify them manually.
 
-If your credentials are in the default location, paying an offer looks like:
+If your macaroon is in the default location, paying an offer looks like:
 
 `lndk-cli pay-offer <OFFER_STRING> <AMOUNT_MSATS>`
 
-If your credentials are not in the default location, an example command looks like:
+If your macaroon is not in the default location, an example command looks like:
 
-`lndk-cli -- --network=mainnet --cert-path=/credentials/tls.cert --macaroon-path=/credentials/custom.macaroon --address=https://localhost:10019 pay-offer <OFFER_STRING> <AMOUNT_MSATS>`
+`lndk-cli -- --network=mainnet --macaroon-path=/credentials/custom.macaroon pay-offer <OFFER_STRING> <AMOUNT_MSATS>`
 
-Or you can pass in the credentials directly via a pem string or macaroon string like:
-`lndk-cli -- --network=mainnet --cert-path=<CERT_PEM_STR> --macaroon-hex=<MACAROON_HEX_STR> --address=https://localhost:10019 pay-offer <OFFER_STRING> <AMOUNT_MSATS>`
+Or you can pass in the credentials directly with a macaroon string like:
+`lndk-cli -- --network=mainnet --macaroon-hex=<MACAROON_HEX_STR> pay-offer <OFFER_STRING> <AMOUNT_MSATS>`
+
+## gRPC client example
+
+Another option for interacting with `LNDK` is to connect to the LNDK server with a gRPC client,
+which you can do in [most languages](https://grpc.io/docs/languages/).
+
+Again, since LNDK needs to connect to LND, you'll need to pass in your LND macaroon to establish a connection. Note that:
+- The client must pass in this data via gRPC metadata. You can find an example of this in the [Rust client](https://github.com/lndk-org/lndk/blob/master/src/cli.rs) used to connect `lndk-cli` to the server.

--- a/proto/lndkrpc.proto
+++ b/proto/lndkrpc.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+package lndkrpc;
+
+service Offers {
+    rpc PayOffer (PayOfferRequest) returns (PayOfferResponse);
+}
+
+message PayOfferRequest {
+   string offer = 1;
+   optional uint64 amount = 2;
+}
+
+message PayOfferResponse {
+    string payment_preimage = 2;
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,6 @@ use clap::{Parser, Subcommand};
 use lndk::lnd::{get_lnd_client, string_to_network, validate_lnd_creds, LndCfg};
 use lndk::lndk_offers::{decode, get_destination};
 use lndk::{Cfg, LifecycleSignals, LndkOnionMessenger, OfferHandler, PayOfferParams};
-use log::LevelFilter;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::select;
@@ -173,8 +172,6 @@ async fn main() -> Result<(), ()> {
             };
             let lndk_cfg = Cfg {
                 lnd: lnd_cfg,
-                log_dir: None,
-                log_level: LevelFilter::Info,
                 signals,
             };
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use clap::{Parser, Subcommand};
 use lndk::lndk_offers::decode;
 use lndk::lndkrpc::offers_client::OffersClient;
 use lndk::lndkrpc::PayOfferRequest;
-use lndk::DEFAULT_SERVER_PORT;
+use lndk::{DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT};
 use std::fs::File;
 use std::io::BufReader;
 use std::io::Read;
@@ -37,6 +37,12 @@ struct Cli {
     /// A hex-encoded macaroon string to pass in directly to the cli.
     #[arg(long, global = true, required = false)]
     macaroon_hex: Option<String>,
+
+    #[arg(long, global = true, required = false, default_value = format!("http://{DEFAULT_SERVER_HOST}"))]
+    grpc_host: String,
+
+    #[arg(long, global = true, required = false, default_value = DEFAULT_SERVER_PORT.to_string())]
+    grpc_port: u16,
 
     #[command(subcommand)]
     command: Commands,
@@ -86,7 +92,9 @@ async fn main() -> Result<(), ()> {
             ref offer_string,
             amount,
         } => {
-            let mut client = OffersClient::connect(format!("http://[::1]:{DEFAULT_SERVER_PORT}"))
+            let grpc_host = args.grpc_host;
+            let grpc_port = args.grpc_port;
+            let mut client = OffersClient::connect(format!("{grpc_host}:{grpc_port}"))
                 .await
                 .map_err(|e| {
                     println!("ERROR: connecting to server {:?}.", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,11 @@ pub mod lnd;
 pub mod lndk_offers;
 pub mod onion_messenger;
 mod rate_limit;
+pub mod server;
+
+pub mod lndkrpc {
+    tonic::include_proto!("lndkrpc");
+}
 
 use crate::lnd::{
     features_support_onion_messages, get_lnd_client, get_network, LndCfg, LndNodeSigner,
@@ -45,6 +50,8 @@ pub fn init_logger(config: LogConfig) {
         log4rs::init_config(config).expect("failed to initialize logger");
     });
 }
+
+pub const DEFAULT_SERVER_PORT: u16 = 7000;
 
 #[allow(clippy::result_unit_err)]
 pub fn setup_logger(log_level: Option<String>, log_dir: Option<String>) -> Result<(), ()> {
@@ -128,7 +135,6 @@ impl LndkOnionMessenger {
         offer_handler: Arc<impl OffersMessageHandler>,
     ) -> Result<(), ()> {
         let mut client = get_lnd_client(args.lnd).expect("failed to connect");
-
         let info = client
             .lightning()
             .get_info(GetInfoRequest {})

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex, Once};
 use tokio::time::{sleep, timeout, Duration};
-use tonic_lnd::lnrpc::GetInfoRequest;
+use tonic_lnd::lnrpc::{GetInfoRequest, Payment};
 use tonic_lnd::Client;
 use triggered::{Listener, Trigger};
 
@@ -242,7 +242,10 @@ impl OfferHandler {
     }
 
     /// Adds an offer to be paid with the amount specified. May only be called once for a single offer.
-    pub async fn pay_offer(&self, cfg: PayOfferParams) -> Result<(), OfferError<Secp256k1Error>> {
+    pub async fn pay_offer(
+        &self,
+        cfg: PayOfferParams,
+    ) -> Result<Payment, OfferError<Secp256k1Error>> {
         let client_clone = cfg.client.clone();
         let offer_id = cfg.offer.clone().to_string();
         let validated_amount = self.send_invoice_request(cfg).await.map_err(|e| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub fn init_logger(config: LogConfig) {
     });
 }
 
+pub const DEFAULT_SERVER_HOST: &str = "127.0.0.1";
 pub const DEFAULT_SERVER_PORT: u16 = 7000;
 
 #[allow(clippy::result_unit_err)]
@@ -68,7 +69,7 @@ pub fn setup_logger(log_level: Option<String>, log_dir: Option<String>) -> Resul
                 return Err(());
             }
         },
-        None => LevelFilter::Info,
+        None => LevelFilter::Trace,
     };
 
     let log_dir = log_dir.unwrap_or_else(|| {

--- a/src/lnd.rs
+++ b/src/lnd.rs
@@ -12,13 +12,16 @@ use lightning::ln::msgs::UnsignedGossipMessage;
 use lightning::offers::invoice::UnsignedBolt12Invoice;
 use lightning::offers::invoice_request::{InvoiceRequest, UnsignedInvoiceRequest};
 use lightning::sign::{KeyMaterial, NodeSigner, Recipient};
+use log::error;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 use std::fmt::Display;
 use std::path::PathBuf;
-use tonic_lnd::lnrpc::{HtlcAttempt, LightningNode, ListPeersResponse, QueryRoutesResponse, Route};
+use tonic_lnd::lnrpc::{
+    GetInfoResponse, HtlcAttempt, LightningNode, ListPeersResponse, QueryRoutesResponse, Route,
+};
 use tonic_lnd::signrpc::KeyLocator;
 use tonic_lnd::tonic::Status;
 use tonic_lnd::{Client, ConnectError};
@@ -282,6 +285,22 @@ impl fmt::Display for NetworkParseError {
             NetworkParseError::Invalid(network_str) => write!(f, "invalid network provided: {network_str}. Should be mainnet, testnet, signet, or regtest."),
         }
     }
+}
+
+// get_network grabs what network lnd is running on from the LND API.
+pub async fn get_network(info: GetInfoResponse) -> Result<Network, ()> {
+    let mut network_str = None;
+    #[allow(deprecated)]
+    for chain in info.chains {
+        if chain.chain == "bitcoin" {
+            network_str = Some(chain.network.clone())
+        }
+    }
+    if network_str.is_none() {
+        error!("lnd node is not connected to bitcoin network as expected");
+        return Err(());
+    }
+    Ok(string_to_network(&network_str.unwrap()).unwrap())
 }
 
 pub fn string_to_network(network_str: &str) -> Result<Network, NetworkParseError> {

--- a/src/lnd.rs
+++ b/src/lnd.rs
@@ -20,7 +20,8 @@ use std::fmt;
 use std::fmt::Display;
 use std::path::PathBuf;
 use tonic_lnd::lnrpc::{
-    GetInfoResponse, HtlcAttempt, LightningNode, ListPeersResponse, QueryRoutesResponse, Route,
+    GetInfoResponse, HtlcAttempt, LightningNode, ListPeersResponse, Payment, QueryRoutesResponse,
+    Route,
 };
 use tonic_lnd::signrpc::KeyLocator;
 use tonic_lnd::tonic::Status;
@@ -359,7 +360,7 @@ pub trait InvoicePayer {
     async fn track_payment(
         &mut self,
         payment_hash: [u8; 32],
-    ) -> Result<(), OfferError<Secp256k1Error>>;
+    ) -> Result<Payment, OfferError<Secp256k1Error>>;
 }
 
 #[cfg(test)]

--- a/src/lndk_offers.rs
+++ b/src/lndk_offers.rs
@@ -21,7 +21,7 @@ use std::fmt::Display;
 use std::str::FromStr;
 use tokio::task;
 use tonic_lnd::lnrpc::{
-    GetInfoRequest, HtlcAttempt, LightningNode, ListPeersRequest, ListPeersResponse,
+    GetInfoRequest, HtlcAttempt, LightningNode, ListPeersRequest, ListPeersResponse, Payment,
     QueryRoutesResponse, Route,
 };
 use tonic_lnd::routerrpc::TrackPaymentRequest;
@@ -260,7 +260,7 @@ impl OfferHandler {
         &self,
         mut payer: impl InvoicePayer + std::marker::Send + 'static,
         params: PayInvoiceParams,
-    ) -> Result<(), OfferError<Secp256k1Error>> {
+    ) -> Result<Payment, OfferError<Secp256k1Error>> {
         let resp = payer
             .query_routes(
                 params.path,
@@ -549,7 +549,7 @@ impl InvoicePayer for Client {
     async fn track_payment(
         &mut self,
         payment_hash: [u8; 32],
-    ) -> Result<(), OfferError<Secp256k1Error>> {
+    ) -> Result<Payment, OfferError<Secp256k1Error>> {
         let req = TrackPaymentRequest {
             payment_hash: payment_hash.to_vec(),
             no_inflight_updates: true,
@@ -565,7 +565,7 @@ impl InvoicePayer for Client {
         // Wait for a failed or successful payment.
         while let Some(payment) = stream.message().await.map_err(OfferError::TrackFailure)? {
             if payment.status() == tonic_lnd::lnrpc::payment::PaymentStatus::Succeeded {
-                return Ok(());
+                return Ok(payment);
             } else if payment.status() == tonic_lnd::lnrpc::payment::PaymentStatus::Failed {
                 return Err(OfferError::PaymentFailure);
             } else {
@@ -589,7 +589,7 @@ mod tests {
     use std::collections::HashMap;
     use std::str::FromStr;
     use std::time::{Duration, SystemTime};
-    use tonic_lnd::lnrpc::NodeAddress;
+    use tonic_lnd::lnrpc::{NodeAddress, Payment};
 
     fn get_offer() -> String {
         "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrcgqgn3qzsyvfkx26qkyypvr5hfx60h9w9k934lt8s2n6zc0wwtgqlulw7dythr83dqx8tzumg".to_string()
@@ -673,7 +673,7 @@ mod tests {
         impl InvoicePayer for TestInvoicePayer{
             async fn query_routes(&mut self, path: BlindedPath, cltv_expiry_delta: u16, fee_base_msat: u32, fee_ppm: u32, msats: u64) -> Result<QueryRoutesResponse, Status>;
             async fn send_to_route(&mut self, payment_hash: [u8; 32], route: Route) -> Result<HtlcAttempt, Status>;
-            async fn track_payment(&mut self, payment_hash: [u8; 32]) -> Result<(), OfferError<Secp256k1Error>>;
+            async fn track_payment(&mut self, payment_hash: [u8; 32]) -> Result<Payment, OfferError<Secp256k1Error>>;
         }
     }
 
@@ -944,7 +944,11 @@ mod tests {
             })
         });
 
-        payer_mock.expect_track_payment().returning(|_| Ok(()));
+        payer_mock.expect_track_payment().returning(|_| {
+            Ok(Payment {
+                ..Default::default()
+            })
+        });
 
         let blinded_path = get_blinded_path();
         let payment_hash = MessengerUtilities::new().get_secure_random_bytes();

--- a/src/lndk_offers.rs
+++ b/src/lndk_offers.rs
@@ -19,7 +19,6 @@ use log::error;
 use std::error::Error;
 use std::fmt::Display;
 use std::str::FromStr;
-use tokio::sync::mpsc::Receiver;
 use tokio::task;
 use tonic_lnd::lnrpc::{
     GetInfoRequest, HtlcAttempt, LightningNode, ListPeersRequest, ListPeersResponse,
@@ -100,14 +99,7 @@ impl OfferHandler {
     pub async fn send_invoice_request(
         &self,
         mut cfg: PayOfferParams,
-        mut started: Receiver<u32>,
     ) -> Result<u64, OfferError<bitcoin::secp256k1::Error>> {
-        // Wait for onion messenger to give us the signal that it's ready. Once the onion messenger drops
-        // the channel sender, recv will return None and we'll stop blocking here.
-        if started.recv().await.is_some() {
-            error!("Error: we shouldn't receive any messages on this channel");
-        }
-
         let validated_amount = validate_amount(&cfg.offer, cfg.amount).await?;
 
         // For now we connect directly to the introduction node of the blinded path so we don't need any

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,18 @@ mod internal {
 }
 
 use internal::*;
-use lndk::lnd::{validate_lnd_creds, LndCfg};
-use lndk::{setup_logger, Cfg, LifecycleSignals, LndkOnionMessenger, OfferHandler};
+use lndk::lnd::{get_lnd_client, validate_lnd_creds, LndCfg};
+use lndk::server::LNDKServer;
+use lndk::{
+    lndkrpc, setup_logger, Cfg, LifecycleSignals, LndkOnionMessenger, OfferHandler,
+    DEFAULT_SERVER_PORT,
+};
+use lndkrpc::offers_server::OffersServer;
+use log::{error, info};
 use std::sync::Arc;
+use tokio::select;
+use tonic::transport::Server;
+use tonic_lnd::lnrpc::GetInfoRequest;
 
 #[macro_use]
 extern crate configure_me;
@@ -32,7 +41,8 @@ async fn main() -> Result<(), ()> {
     .map_err(|e| {
         println!("Error validating config: {e}.");
     })?;
-    let lnd_args = LndCfg::new(config.address, creds);
+    let address = config.address.clone();
+    let lnd_args = LndCfg::new(config.address, creds.clone());
 
     let (shutdown, listener) = triggered::trigger();
     let signals = LifecycleSignals { shutdown, listener };
@@ -42,8 +52,47 @@ async fn main() -> Result<(), ()> {
     };
 
     let handler = Arc::new(OfferHandler::new());
+    let messenger = LndkOnionMessenger::new();
     setup_logger(config.log_level, config.log_dir)?;
 
-    let messenger = LndkOnionMessenger::new();
-    messenger.run(args, Arc::clone(&handler)).await
+    let mut client = get_lnd_client(args.lnd.clone()).expect("failed to connect to lnd");
+    let info = client
+        .lightning()
+        .get_info(GetInfoRequest {})
+        .await
+        .expect("failed to get info")
+        .into_inner();
+
+    let addr = format!("[::1]:{DEFAULT_SERVER_PORT}")
+        .parse()
+        .map_err(|e| {
+            error!("Error parsing API address: {e}");
+        })?;
+
+    let tls_str = creds.get_certificate_string()?;
+    let server = LNDKServer::new(
+        Arc::clone(&handler),
+        &info.identity_pubkey,
+        tls_str,
+        address,
+    )
+    .await;
+
+    let server_fut = Server::builder()
+        .add_service(OffersServer::new(server))
+        .serve(addr);
+
+    select! {
+       _ = messenger.run(args, Arc::clone(&handler)) => {
+           info!("Onion messenger completed");
+       },
+       result2 = server_fut => {
+            match result2 {
+                Ok(_) => info!("API completed"),
+                Err(e) => error!("Error running API: {}", e),
+            };
+       },
+    }
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use lndk::lnd::{validate_lnd_creds, LndCfg};
 use lndk::{Cfg, LifecycleSignals, LndkOnionMessenger, OfferHandler};
 use log::LevelFilter;
 use std::str::FromStr;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::{Receiver, Sender};
 
@@ -68,7 +69,7 @@ async fn main() -> Result<(), ()> {
         signals,
     };
 
-    let handler = OfferHandler::new();
-    let messenger = LndkOnionMessenger::new(handler);
-    messenger.run(args).await
+    let handler = Arc::new(OfferHandler::new());
+    let messenger = LndkOnionMessenger::new();
+    messenger.run(args, Arc::clone(&handler)).await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,6 @@ use internal::*;
 use lndk::lnd::{validate_lnd_creds, LndCfg};
 use lndk::{setup_logger, Cfg, LifecycleSignals, LndkOnionMessenger, OfferHandler};
 use std::sync::Arc;
-use tokio::sync::mpsc;
-use tokio::sync::mpsc::{Receiver, Sender};
 
 #[macro_use]
 extern crate configure_me;
@@ -37,13 +35,7 @@ async fn main() -> Result<(), ()> {
     let lnd_args = LndCfg::new(config.address, creds);
 
     let (shutdown, listener) = triggered::trigger();
-    // Create the channel which will tell us when the onion messenger has finished starting up.
-    let (tx, _): (Sender<u32>, Receiver<u32>) = mpsc::channel(1);
-    let signals = LifecycleSignals {
-        shutdown,
-        listener,
-        started: tx,
-    };
+    let signals = LifecycleSignals { shutdown, listener };
     let args = Cfg {
         lnd: lnd_args,
         signals,

--- a/src/onion_messenger.rs
+++ b/src/onion_messenger.rs
@@ -20,7 +20,6 @@ use lightning::util::ser::{Readable, Writeable};
 use log::{debug, error, info, trace, warn};
 use rand_chacha::ChaCha20Rng;
 use rand_core::{RngCore, SeedableRng};
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
@@ -50,19 +49,11 @@ const DEFAULT_CALL_FREQUENCY: Duration = Duration::from_secs(1);
 
 /// MessengerUtilities is a utility struct used to provide Logger and EntropySource trait implementations for LDK’s
 /// OnionMessenger.
-///
-/// A refcell is used for entropy_source to provide interior mutability for ChaCha20Rng. We need a mutable reference
-/// to be able to use the chacha library’s fill_bytes method, but the EntropySource interface in LDK is for an
-/// immutable reference.
-pub struct MessengerUtilities {
-    entropy_source: RefCell<ChaCha20Rng>,
-}
+pub struct MessengerUtilities {}
 
 impl MessengerUtilities {
     pub fn new() -> Self {
-        MessengerUtilities {
-            entropy_source: RefCell::new(ChaCha20Rng::from_entropy()),
-        }
+        MessengerUtilities {}
     }
 }
 
@@ -75,10 +66,9 @@ impl Default for MessengerUtilities {
 impl EntropySource for MessengerUtilities {
     // TODO: surface LDK's EntropySource and use instead.
     fn get_secure_random_bytes(&self) -> [u8; 32] {
+        let mut entropy_source = ChaCha20Rng::from_entropy();
         let mut chacha_bytes: [u8; 32] = [0; 32];
-        self.entropy_source
-            .borrow_mut()
-            .fill_bytes(&mut chacha_bytes);
+        entropy_source.fill_bytes(&mut chacha_bytes);
         chacha_bytes
     }
 }

--- a/src/onion_messenger.rs
+++ b/src/onion_messenger.rs
@@ -75,6 +75,7 @@ impl EntropySource for MessengerUtilities {
 
 impl Logger for MessengerUtilities {
     fn log(&self, record: Record) {
+        //println!("ARE WE GETTING ANY LDK LOGS??? {record:?}");
         let args_str = record.args.to_string();
         match record.level {
             Level::Gossip => {}

--- a/src/onion_messenger.rs
+++ b/src/onion_messenger.rs
@@ -208,9 +208,6 @@ impl LndkOnionMessenger {
             }
         });
 
-        // By dropping the sender, we signal to the receiver that the onion messenger has successfully started up.
-        drop(signals.started);
-
         // Consume events is our main controlling loop, so we run it inline here. We use a RefCell in onion_messenger to
         // allow interior mutability (see LndNodeSigner) so this function can't safely be passed off to another thread.
         // This function is expected to finish if any producing thread exits (because we're no longer receiving the

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,137 @@
+use crate::lnd::{get_lnd_client, get_network, Creds, LndCfg};
+use crate::lndk_offers::get_destination;
+use crate::{lndkrpc, OfferError, OfferHandler, PayOfferParams};
+use bitcoin::secp256k1::PublicKey;
+use lightning::offers::offer::Offer;
+use lndkrpc::offers_server::Offers;
+use lndkrpc::{PayOfferRequest, PayOfferResponse};
+use std::str::FromStr;
+use std::sync::Arc;
+use tonic::metadata::MetadataMap;
+use tonic::{Request, Response, Status};
+use tonic_lnd::lnrpc::GetInfoRequest;
+pub struct LNDKServer {
+    offer_handler: Arc<OfferHandler>,
+    node_id: PublicKey,
+    // The LND tls cert we need to establish a connection with LND.
+    lnd_cert: String,
+    address: String,
+}
+
+impl LNDKServer {
+    pub async fn new(
+        offer_handler: Arc<OfferHandler>,
+        node_id: &str,
+        lnd_cert: String,
+        address: String,
+    ) -> Self {
+        Self {
+            offer_handler,
+            node_id: PublicKey::from_str(node_id).unwrap(),
+            lnd_cert,
+            address,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl Offers for LNDKServer {
+    async fn pay_offer(
+        &self,
+        request: Request<PayOfferRequest>,
+    ) -> Result<Response<PayOfferResponse>, Status> {
+        log::info!("Received a request: {:?}", request);
+
+        let metadata = request.metadata();
+        let macaroon = check_auth_metadata(metadata)?;
+        let creds = Creds::String {
+            cert: self.lnd_cert.clone(),
+            macaroon,
+        };
+        let lnd_cfg = LndCfg::new(self.address.clone(), creds);
+        let mut client = get_lnd_client(lnd_cfg)
+            .map_err(|e| Status::unavailable(format!("Couldn't connect to lnd: {e}")))?;
+
+        let inner_request = request.get_ref();
+        let offer = Offer::from_str(&inner_request.offer).map_err(|e| {
+            Status::invalid_argument(format!(
+                "The provided offer was invalid. Please provide a valid offer in bech32 format,
+                i.e. starting with 'lno'. Error: {e:?}"
+            ))
+        })?;
+
+        let destination = get_destination(&offer).await;
+        let reply_path = match self
+            .offer_handler
+            .create_reply_path(client.clone(), self.node_id)
+            .await
+        {
+            Ok(reply_path) => reply_path,
+            Err(e) => return Err(Status::internal(format!("Internal error: {e}"))),
+        };
+
+        let info = client
+            .lightning()
+            .get_info(GetInfoRequest {})
+            .await
+            .expect("failed to get info")
+            .into_inner();
+        let network = get_network(info)
+            .await
+            .map_err(|e| Status::internal(format!("{e:?}")))?;
+
+        let cfg = PayOfferParams {
+            offer,
+            amount: inner_request.amount,
+            network,
+            client,
+            destination,
+            reply_path: Some(reply_path),
+        };
+
+        let payment = match self.offer_handler.pay_offer(cfg).await {
+            Ok(payment) => {
+                log::info!("Payment succeeded.");
+                payment
+            }
+            Err(e) => match e {
+                OfferError::AlreadyProcessing => {
+                    return Err(Status::already_exists(format!("{e}")))
+                }
+                OfferError::InvalidAmount(e) => {
+                    return Err(Status::invalid_argument(e.to_string()))
+                }
+                OfferError::InvalidCurrency => {
+                    return Err(Status::invalid_argument(format!("{e}")))
+                }
+                _ => return Err(Status::internal(format!("Internal error: {e}"))),
+            },
+        };
+
+        let reply = PayOfferResponse {
+            payment_preimage: payment.payment_preimage,
+        };
+
+        Ok(Response::new(reply))
+    }
+}
+
+// We need to check that the client passes in a tls cert pem string, hexadecimal macaroon,
+// and address, so they can connect to LND.
+fn check_auth_metadata(metadata: &MetadataMap) -> Result<String, Status> {
+    let macaroon = match metadata.get("macaroon") {
+        Some(macaroon_hex) => macaroon_hex
+            .to_str()
+            .map_err(|e| {
+                Status::invalid_argument(format!("Invalid macaroon string provided: {e}"))
+            })?
+            .to_string(),
+        _ => {
+            return Err(Status::unauthenticated(
+                "No LND macaroon provided: Make sure to provide macaroon in request metadata",
+            ))
+        }
+    };
+
+    Ok(macaroon)
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -53,7 +53,7 @@ async fn check_for_message(ldk: LdkNode) -> LdkNode {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_lndk_forwards_onion_message() {
     let test_name = "lndk_forwards_onion_message";
-    let (_bitcoind, mut lnd, ldk1, ldk2, _lndk_dir) =
+    let (_bitcoind, mut lnd, ldk1, ldk2, lndk_dir) =
         common::setup_test_infrastructure(test_name).await;
 
     // Here we'll produce a little path of two channels. Both ldk nodes are connected to lnd like so:
@@ -88,6 +88,15 @@ async fn test_lndk_forwards_onion_message() {
         lnd: lnd_cfg,
         signals,
     };
+
+    let log_dir = Some(
+        lndk_dir
+            .join(format!("lndk-logs.txt"))
+            .to_str()
+            .unwrap()
+            .to_string(),
+    );
+    setup_logger(None, log_dir).unwrap();
 
     let handler = Arc::new(lndk::OfferHandler::new());
     let messenger = lndk::LndkOnionMessenger::new();
@@ -270,6 +279,15 @@ async fn test_lndk_send_invoice_request() {
         lnd: lnd_cfg,
         signals,
     };
+
+    let log_dir = Some(
+        lndk_dir
+            .join(format!("lndk-logs.txt"))
+            .to_str()
+            .unwrap()
+            .to_string(),
+    );
+    setup_logger(None, log_dir).unwrap();
 
     let handler = Arc::new(lndk::OfferHandler::new());
     let messenger = lndk::LndkOnionMessenger::new();


### PR DESCRIPTION
This PR sets up a grpc server for interacting with a running LNDK instance. The main command it supports right now is to pay an offer. 

In summary:
- The first few commits are preparatory to pave the way for the grpc server. 
- To interact with LND we need the user to pass in their LND macaroon. We use grpc metadata for this to make it easy to tag this on to each API call.
- Updates the CLI to connect to the server.