### PR TITLE
actions: pin Rust version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ on:
 env:
   GO_VERSION: 1.21.0
 
+  RUST_VERSION: 1.78.0
+
 jobs:
   build_and_format:
     name: LNDK Rust Build
@@ -17,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ env.GO_VERSION }}
       - run: sudo apt-get install protobuf-compiler
       - uses: actions-rs/cargo@v1
         name: cargo build
@@ -47,7 +49,7 @@ jobs:
           submodules: 'true'
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ env.GO_VERSION }}
       - run: sudo apt-get install protobuf-compiler
       - name: setup go ${{ env.GO_VERSION }}
         uses: lightningnetwork/lnd/.github/actions/setup-go@v0-16-4-branch
@@ -67,7 +69,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ env.GO_VERSION }}
       - run: sudo apt-get install protobuf-compiler
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-#[allow(unused_imports)]
 mod internal {
+    #![allow(unused_imports)]
     #![allow(clippy::enum_variant_names)]
     #![allow(clippy::unnecessary_lazy_evaluations)]
     #![allow(clippy::useless_conversion)]


### PR DESCRIPTION
This PR does a couple of things to fix our github actions/CI process:
- Pins the Rust version in Github Actions, because otherwise we get unexpected, new clippy errors when Rust stable has been upgraded to a newer version. Note that this means we'll need to manually upgrade the Rust version in github actions from now on.
- Fixes an attribute problem that clippy didn't like.