### PR TITLE
Check LND has required version and build tags on start LNDK.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ log4rs = { version = "1.2.0", features = ["file_appender"] }
 rcgen = { version = "0.13.1", features = ["pem", "x509-parser"] }
 tokio = { version = "1.25.0", features = ["rt", "rt-multi-thread"] }
 tonic = { version = "0.11", features = [ "tls", "transport" ] }
-tonic_lnd = { git = "https://github.com/orbitalturtle/tonic_lnd", rev="18c5a71084886024a6b90307bfb8822288c5daea", package="fedimint-tonic-lnd", features = ["lightningrpc", "routerrpc"] }
+tonic_lnd = { git = "https://github.com/orbitalturtle/tonic_lnd", rev="18c5a71084886024a6b90307bfb8822288c5daea", package="fedimint-tonic-lnd", features = ["lightningrpc", "routerrpc", "versionrpc"] }
 hex = "0.4.3"
 configure_me = "0.4.0"
 bytes = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Or in a more concrete example:
 Rather than use the admin.macaroon with unrestricted permission to an `LND` node, we can bake a macaroon using lncli with much more specific permissions for better security. With this command, generate a macaroon which will give `LNDK` only the specific grpc endpoints it's designed to hit:
 
 ```
-lncli bakemacaroon --save_to=<FILEPATH>/lndk.macaroon uri:/lnrpc.Lightning/GetInfo uri:/lnrpc.Lightning/ListPeers uri:/lnrpc.Lightning/SubscribePeerEvents uri:/lnrpc.Lightning/SendCustomMessage uri:/lnrpc.Lightning/SubscribeCustomMessages uri:/peersrpc.Peers/UpdateNodeAnnouncement uri:/signrpc.Signer/DeriveSharedKey
+lncli bakemacaroon --save_to=<FILEPATH>/lndk.macaroon uri:/lnrpc.Lightning/GetInfo uri:/lnrpc.Lightning/ListPeers uri:/lnrpc.Lightning/SubscribePeerEvents uri:/lnrpc.Lightning/SendCustomMessage uri:/lnrpc.Lightning/SubscribeCustomMessages uri:/peersrpc.Peers/UpdateNodeAnnouncement uri:/signrpc.Signer/DeriveSharedKey uri:/verrpc.Versioner/GetVersion
 ```
 
 ## Security

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -56,3 +56,9 @@ name = "grpc_port"
 type = "u16"
 optional = true
 doc = "The port the grpc server will run on. Defaults to 7000."
+
+[[param]]
+name = "skip_version_check"
+type = "bool"
+default = "false"
+doc = "Skip checking the LND version. Otherwise, LNDK checks that the LND version is compatible with LNDK."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@ pub fn setup_logger(log_level: Option<String>, log_dir: Option<String>) -> Resul
 pub struct Cfg {
     pub lnd: LndCfg,
     pub signals: LifecycleSignals,
+    pub skip_version_check: bool,
 }
 
 #[derive(Clone)]
@@ -181,7 +182,7 @@ impl LndkOnionMessenger {
             return Err(());
         }
 
-        if !has_version(&version, None) {
+        if !args.skip_version_check && !has_version(&version, None) {
             error!(
                     "The LND version {} is not compatible with LNDK. Please update to version {}.{}.{}-{} or higher.",
                     &version.version, MIN_LND_MAJOR_VER, MIN_LND_MINOR_VER, MIN_LND_PATCH_VER, MIN_LND_PRE_RELEASE_VER

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,9 @@ pub mod lndkrpc {
 }
 
 use crate::lnd::{
-    features_support_onion_messages, get_lnd_client, get_network, LndCfg, LndNodeSigner,
+    features_support_onion_messages, get_lnd_client, get_network, has_build_tags, has_version,
+    LndCfg, LndNodeSigner, MIN_LND_MAJOR_VER, MIN_LND_MINOR_VER, MIN_LND_PATCH_VER,
+    MIN_LND_PRE_RELEASE_VER,
 };
 use crate::lndk_offers::{OfferError, PayInvoiceParams};
 use crate::onion_messenger::{LndkNodeIdLookUp, MessengerUtilities};
@@ -31,6 +33,7 @@ use lightning::onion_message::messenger::{
 use lightning::onion_message::offers::{OffersMessage, OffersMessageHandler};
 use lightning::routing::gossip::NetworkGraph;
 use lightning::sign::{EntropySource, KeyMaterial};
+use lnd::BUILD_TAGS_REQUIRED;
 use log::{debug, error, info, LevelFilter};
 use log4rs::append::console::ConsoleAppender;
 use log4rs::append::file::FileAppender;
@@ -41,6 +44,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex, Once};
 use tokio::time::{sleep, timeout, Duration};
 use tonic_lnd::lnrpc::{ChanInfoRequest, GetInfoRequest, Payment};
+use tonic_lnd::verrpc::VersionRequest;
 use tonic_lnd::Client;
 use triggered::{Listener, Trigger};
 
@@ -158,6 +162,30 @@ impl LndkOnionMessenger {
 
         if !features_support_onion_messages(&info.features) {
             error!("LND must support onion messaging to run LNDK.");
+            return Err(());
+        }
+
+        let version = client
+            .versioner()
+            .get_version(VersionRequest {})
+            .await
+            .expect("failed to get version")
+            .into_inner();
+
+        if !has_build_tags(&version, None) {
+            error!(
+                "LND build tags '{}' are not compatible with LNDK. Make sure '{}' are enabled.",
+                &version.build_tags.join(", "),
+                BUILD_TAGS_REQUIRED.join(", ")
+            );
+            return Err(());
+        }
+
+        if !has_version(&version, None) {
+            error!(
+                    "The LND version {} is not compatible with LNDK. Please update to version {}.{}.{}-{} or higher.",
+                    &version.version, MIN_LND_MAJOR_VER, MIN_LND_MINOR_VER, MIN_LND_PATCH_VER, MIN_LND_PRE_RELEASE_VER
+                );
             return Err(());
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ async fn main() -> Result<(), ()> {
     let args = Cfg {
         lnd: lnd_args,
         signals,
+        skip_version_check: config.skip_version_check,
     };
 
     let handler = Arc::new(OfferHandler::new());

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -183,6 +183,7 @@ pub async fn setup_lndk(
     let lndk_cfg = lndk::Cfg {
         lnd: lnd_cfg,
         signals,
+        skip_version_check: false,
     };
 
     // Make sure lndk successfully sends the invoice_request.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -174,6 +174,7 @@ async fn test_lndk_send_invoice_request() {
     let lndk_cfg = lndk::Cfg {
         lnd: lnd_cfg.clone(),
         signals,
+        skip_version_check: false,
     };
 
     let mut client = lnd.client.clone().unwrap();
@@ -256,6 +257,7 @@ async fn test_lndk_send_invoice_request() {
     let lndk_cfg = lndk::Cfg {
         lnd: lnd_cfg,
         signals,
+        skip_version_check: false,
     };
 
     let log_dir = Some(


### PR DESCRIPTION
This PR resolves #30 
Check version and build tags of connecting LND at the start of LNDK.

We could make the `has_version` function smaller, but I chose clarity over shotness.
The `has_version` and `has_tags` functions have an optional `requirement` argument, so we can test these functions with constants dedicated to the unit testing.

I have found that LND does not strictly follow semantic versioning. 
LND always release with `beta` pre-release version. Release candidate versions are tagged with something like `beta.rc1`.  If I understand correctly, `0.18.0-beta` < `0.18.0-beta.rc` right?