### PR TITLE
secure the gRPC server with TLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ad1373757efa0f70ec53939aabc7152e1591cb485208052993070ac8d2429d"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.36",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +250,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bech32"
@@ -521,6 +566,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +616,17 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "downcast"
@@ -587,8 +672,8 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "prost",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.10",
+ "rustls-pemfile 1.0.4",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
@@ -906,9 +991,9 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "rustls",
+ "rustls 0.21.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -1170,6 +1255,7 @@ dependencies = [
  "prost",
  "rand_chacha",
  "rand_core 0.6.4",
+ "rcgen",
  "tempfile",
  "tokio",
  "tonic 0.11.0",
@@ -1256,6 +1342,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,8 +1364,8 @@ checksum = "cb3371dfc7b772c540da1380123674a8e20583aca99907087d990ca58cf44203"
 dependencies = [
  "log",
  "once_cell",
- "rustls",
- "rustls-webpki",
+ "rustls 0.21.10",
+ "rustls-webpki 0.101.7",
  "webpki-roots",
 ]
 
@@ -1330,10 +1422,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1361,6 +1488,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c958dd45046245b9c3c2547369bb634eb461670b2e7e0de552905801a648d1d"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -1406,6 +1542,16 @@ name = "parse_arg"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14248cc8eced350e20122a291613de29e4fa129ba2731818c4cdbb44fccd3e55"
+
+[[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1460,6 +1606,12 @@ name = "pkg-config"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1638,6 +1790,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54077e1872c46788540de1ea3d7f4ccb1983d12f9aa909b234468676c1a36779"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time 0.3.36",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,6 +1877,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,8 +1906,22 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1745,12 +1934,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
+dependencies = [
+ "base64 0.21.7",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4ca26037c909dedb327b48c3327d0ba91d3dd3c4e05dad328f210ffb68e95b"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -1913,6 +2129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,6 +2161,17 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "tar"
@@ -2011,6 +2244,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tokio"
 version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2054,7 +2318,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -2111,10 +2386,10 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.10",
+ "rustls-pemfile 1.0.4",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -2141,7 +2416,10 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-pemfile 2.0.0",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls 0.25.0",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -2556,6 +2834,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.36",
+]
+
+[[package]]
 name = "xattr"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2576,6 +2872,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time 0.3.36",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+
+[[package]]
 name = "zip"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2586,5 +2897,5 @@ dependencies = [
  "crc32fast",
  "flate2",
  "thiserror",
- "time",
+ "time 0.1.45",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,9 @@ rand_chacha = "0.3.1"
 rand_core = "0.6.4"
 log = "0.4.17"
 log4rs = { version = "1.2.0", features = ["file_appender"] }
+rcgen = { version = "0.13.1", features = ["pem", "x509-parser"] }
 tokio = { version = "1.25.0", features = ["rt", "rt-multi-thread"] }
-tonic = "0.11"
+tonic = { version = "0.11", features = [ "tls", "transport" ] }
 tonic_lnd = { git = "https://github.com/orbitalturtle/tonic_lnd", rev="afb0187621bca604f606cacfe3cb2aedf5d2fc89", package="fedimint-tonic-lnd", features = ["lightningrpc", "routerrpc"] }
 hex = "0.4.3"
 configure_me = "0.4.0"

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -37,7 +37,7 @@ doc = "The hex encoded macaroon to pass directly into LNDK"
 [[param]]
 name = "log_dir"
 type = "String"
-doc = "The path to the lndk log file"
+doc = "The path to the lndk log file. By default this is stored in ~/.lndk"
 
 [[param]]
 name = "log_level"

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -55,3 +55,9 @@ which you can do in [most languages](https://grpc.io/docs/languages/).
 
 Again, since LNDK needs to connect to LND, you'll need to pass in your LND macaroon to establish a connection. Note that:
 - The client must pass in this data via gRPC metadata. You can find an example of this in the [Rust client](https://github.com/lndk-org/lndk/blob/master/src/cli.rs) used to connect `lndk-cli` to the server.
+
+## TLS: Running `lndk-cli` remotely
+
+When `LNDK` is started up, self-signed TLS credentials are automatically generated and stored in `~/.lndk`. If you're running `lndk-cli` locally, it'll know where to find the certificate file it needs to establish a secure connection with the LNDK server.
+
+To run `lndk-cli` on a remote machine, users need to copy the `tls-cert.pem` file to the corresponding LNDK data directory (`~/.lndk`) on the machine where `lndk-cli` is being run.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub fn init_logger(config: LogConfig) {
 pub const DEFAULT_SERVER_HOST: &str = "127.0.0.1";
 pub const DEFAULT_SERVER_PORT: u16 = 7000;
 pub const LDK_LOGGER_NAME: &str = "ldk";
+pub const DEFAULT_DATA_DIR: &str = ".lndk";
 
 #[allow(clippy::result_unit_err)]
 pub fn setup_logger(log_level: Option<String>, log_dir: Option<String>) -> Result<(), ()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,9 @@ pub const DEFAULT_SERVER_PORT: u16 = 7000;
 pub const LDK_LOGGER_NAME: &str = "ldk";
 pub const DEFAULT_DATA_DIR: &str = ".lndk";
 
+pub const TLS_CERT_FILENAME: &str = "tls-cert.pem";
+pub const TLS_KEY_FILENAME: &str = "tls-key.pem";
+
 #[allow(clippy::result_unit_err)]
 pub fn setup_logger(log_level: Option<String>, log_dir: Option<String>) -> Result<(), ()> {
     let log_level = match log_level {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod internal {
 use home::home_dir;
 use internal::*;
 use lndk::lnd::{get_lnd_client, validate_lnd_creds, LndCfg};
-use lndk::server::LNDKServer;
+use lndk::server::{generate_tls_creds, read_tls, LNDKServer};
 use lndk::{
     lndkrpc, setup_logger, Cfg, LifecycleSignals, LndkOnionMessenger, OfferHandler,
     DEFAULT_DATA_DIR, DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT,
@@ -23,7 +23,7 @@ use std::fs::create_dir_all;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::select;
-use tonic::transport::Server;
+use tonic::transport::{Server, ServerTlsConfig};
 use tonic_lnd::lnrpc::GetInfoRequest;
 
 #[macro_use]
@@ -57,7 +57,7 @@ async fn main() -> Result<(), ()> {
     let handler = Arc::new(OfferHandler::new());
     let messenger = LndkOnionMessenger::new();
 
-    let _data_dir =
+    let data_dir =
         create_data_dir().map_err(|e| println!("Error creating LNDK's data dir {e:?}"))?;
     setup_logger(config.log_level, config.log_dir)?;
 
@@ -80,17 +80,28 @@ async fn main() -> Result<(), ()> {
     let addr = format!("{grpc_host}:{grpc_port}").parse().map_err(|e| {
         error!("Error parsing API address: {e}");
     })?;
+    let lnd_tls_str = creds.get_certificate_string()?;
 
-    let tls_str = creds.get_certificate_string()?;
+    // The user passed in a TLS cert to help us establish a secure connection to LND. But now we
+    // need to generate a TLS credentials for connecting securely to the LNDK server.
+    generate_tls_creds(data_dir.clone()).map_err(|e| {
+        error!("Error generating tls credentials: {e}");
+    })?;
+    let identity = read_tls(data_dir).map_err(|e| {
+        error!("Error reading tls credentials: {e}");
+    })?;
+
     let server = LNDKServer::new(
         Arc::clone(&handler),
         &info.identity_pubkey,
-        tls_str,
+        lnd_tls_str,
         address,
     )
     .await;
 
     let server_fut = Server::builder()
+        .tls_config(ServerTlsConfig::new().identity(identity))
+        .expect("couldn't configure tls")
         .add_service(OffersServer::new(server))
         .serve(addr);
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,13 +1,23 @@
 use crate::lnd::{get_lnd_client, get_network, Creds, LndCfg};
 use crate::lndk_offers::get_destination;
-use crate::{lndkrpc, OfferError, OfferHandler, PayOfferParams};
+use crate::{
+    lndkrpc, OfferError, OfferHandler, PayOfferParams, TLS_CERT_FILENAME, TLS_KEY_FILENAME,
+};
 use bitcoin::secp256k1::PublicKey;
 use lightning::offers::offer::Offer;
 use lndkrpc::offers_server::Offers;
 use lndkrpc::{PayOfferRequest, PayOfferResponse};
+use rcgen::{generate_simple_self_signed, CertifiedKey, Error as RcgenError};
+use std::error::Error;
+use std::fmt::Display;
+use std::fs::{metadata, set_permissions, File};
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use tonic::metadata::MetadataMap;
+use tonic::transport::Identity;
 use tonic::{Request, Response, Status};
 use tonic_lnd::lnrpc::GetInfoRequest;
 pub struct LNDKServer {
@@ -134,4 +144,64 @@ fn check_auth_metadata(metadata: &MetadataMap) -> Result<String, Status> {
     };
 
     Ok(macaroon)
+}
+
+/// An error that occurs when generating TLS credentials.
+#[derive(Debug)]
+pub enum CertificateGenFailure {
+    RcgenError(RcgenError),
+    IoError(std::io::Error),
+}
+
+impl Display for CertificateGenFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CertificateGenFailure::RcgenError(e) => {
+                write!(f, "Error generating TLS certificate: {e:?}")
+            }
+            CertificateGenFailure::IoError(e) => write!(f, "IO error: {e:?}"),
+        }
+    }
+}
+
+impl Error for CertificateGenFailure {}
+
+// If a tls cert/key pair doesn't already exist, generate_tls_creds creates the tls cert/key pair
+// required secure connections to LNDK's gRPC server. By default they are stored in ~/.lndk.
+pub fn generate_tls_creds(data_dir: PathBuf) -> Result<(), CertificateGenFailure> {
+    let cert_path = data_dir.join(TLS_CERT_FILENAME);
+    let key_path = data_dir.join(TLS_KEY_FILENAME);
+
+    // Did we have to generate a new key? In that case we also need to regenerate the certificate.
+    if !key_path.exists() || !cert_path.exists() {
+        log::debug!("Generating fresh TLS credentials in {data_dir:?}");
+        let subject_alt_names = vec!["localhost".to_string()];
+
+        let CertifiedKey { cert, key_pair } = generate_simple_self_signed(subject_alt_names)
+            .map_err(CertificateGenFailure::RcgenError)?;
+
+        // Create the tls files. Make sure the key is user-readable only:
+        let mut file = File::create(&key_path).map_err(CertificateGenFailure::IoError)?;
+        let mut perms = metadata(&key_path)
+            .map_err(CertificateGenFailure::IoError)?
+            .permissions();
+        perms.set_mode(0o600);
+        set_permissions(&key_path, perms).map_err(CertificateGenFailure::IoError)?;
+
+        file.write_all(key_pair.serialize_pem().as_bytes())
+            .map_err(CertificateGenFailure::IoError)?;
+        drop(file);
+
+        std::fs::write(&cert_path, cert.pem()).map_err(CertificateGenFailure::IoError)?;
+    };
+
+    Ok(())
+}
+
+// Read the existing tls credentials from disk.
+pub fn read_tls(data_dir: PathBuf) -> Result<Identity, std::io::Error> {
+    let cert = std::fs::read_to_string(data_dir.join(TLS_CERT_FILENAME))?;
+    let key = std::fs::read_to_string(data_dir.join(TLS_KEY_FILENAME))?;
+
+    Ok(Identity::from_pem(cert, key))
 }


### PR DESCRIPTION
In a nutshell this PR:
- Requires TLS to be used when connecting to the gRPC server, and generates self-signed certificates for doing so.
- Updates `lndk-cli` to meet this requirement.
- Updates the documentation.

Note that the cert generation portion takes a little inspiration from TEOS and CLN. Credit where it's due!