### PR TITLE
Cleanup: cargo fmt max comment length

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Generate code coverage
         run: cargo llvm-cov --bin lndk --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: lcov.info
           fail_ci_if_error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         name: cargo fmt
         with:
           command: fmt
-          args: --check
+          args: -- --config unstable_features=true --config wrap_comments=true --config comment_width=100 --check
       - uses: actions-rs/cargo@v1
         name: cargo clippy
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 lndk.conf*
+/.vscode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ General guidelines for code contribution:
 
 #### Conventions
 The following conventions are use for code style (and enforced by the CI): 
-1. Rust format: `cargo fmt`
+1. Rust format: `cargo fmt -- --config unstable_features=true --config wrap_comments=true --config comment_width=100`. We require a few config parameters when formatting to enforce a maximum comment length per-line.
 2. Clippy: 
 ```
 rustup component add clippy

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -118,8 +118,8 @@ async fn main() -> Result<(), ()> {
                 return Err(());
             }
 
-            // Let's grab the macaroon string now. If neither macaroon_path nor macaroon_hex are set, use the
-            // default macaroon path.
+            // Let's grab the macaroon string now. If neither macaroon_path nor macaroon_hex are
+            // set, use the default macaroon path.
             let macaroon = match args.macaroon_path {
                 Some(path) => read_macaroon_from_file(path)
                     .map_err(|e| println!("ERROR reading macaroon from file {e:?}"))?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,8 +152,9 @@ impl LndkOnionMessenger {
             return Err(());
         }
 
-        // On startup, we want to get a list of our currently online peers to notify the onion messenger that they are
-        // connected. This sets up our "start state" for the messenger correctly.
+        // On startup, we want to get a list of our currently online peers to notify the onion
+        // messenger that they are connected. This sets up our "start state" for the
+        // messenger correctly.
         let current_peers = client
             .lightning()
             .list_peers(tonic_lnd::lnrpc::ListPeersRequest {
@@ -229,7 +230,8 @@ pub struct PayOfferParams {
     pub client: Client,
     /// The destination the offer creator provided, which we will use to send the invoice request.
     pub destination: Destination,
-    /// The path we will send back to the offer creator, so it knows where to send back the invoice.
+    /// The path we will send back to the offer creator, so it knows where to send back the
+    /// invoice.
     pub reply_path: Option<BlindedPath>,
 }
 
@@ -248,7 +250,8 @@ impl OfferHandler {
         }
     }
 
-    /// Adds an offer to be paid with the amount specified. May only be called once for a single offer.
+    /// Adds an offer to be paid with the amount specified. May only be called once for a single
+    /// offer.
     pub async fn pay_offer(
         &self,
         cfg: PayOfferParams,
@@ -333,10 +336,10 @@ impl OffersMessageHandler for OfferHandler {
                 let secp_ctx = &Secp256k1::new();
                 // We verify that this invoice is a response to the invoice request we just sent.
                 match invoice.verify(&self.expanded_key, secp_ctx) {
-                    // TODO: Eventually when we allow for multiple payments in flight, we can use the
-                    // returned payment id below to check if we already processed an invoice for
-                    // this payment. Right now it's safe to let this be because we won't try to pay
-                    // a second invoice (if it comes through).
+                    // TODO: Eventually when we allow for multiple payments in flight, we can use
+                    // the returned payment id below to check if we already processed an invoice
+                    // for this payment. Right now it's safe to let this be because we won't try to
+                    // pay a second invoice (if it comes through).
                     Ok(_payment_id) => {
                         let mut active_invoices = self.active_invoices.lock().unwrap();
                         active_invoices.push(invoice.clone());

--- a/src/lnd.rs
+++ b/src/lnd.rs
@@ -30,7 +30,8 @@ use tonic_lnd::{Client, ConnectError};
 const ONION_MESSAGES_REQUIRED: u32 = 38;
 pub(crate) const ONION_MESSAGES_OPTIONAL: u32 = 39;
 
-/// get_lnd_client connects to LND's grpc api using the config provided, blocking until a connection is established.
+/// get_lnd_client connects to LND's grpc api using the config provided, blocking until a connection
+/// is established.
 pub fn get_lnd_client(cfg: LndCfg) -> Result<Client, ConnectError> {
     match cfg.creds {
         Creds::Path { macaroon, cert } => block_on(tonic_lnd::connect(cfg.address, cert, macaroon)),
@@ -173,7 +174,8 @@ impl Creds {
     }
 }
 
-/// features_support_onion_messages returns a boolean indicating whether a feature set supports onion messaging.
+/// features_support_onion_messages returns a boolean indicating whether a feature set supports
+/// onion messaging.
 pub fn features_support_onion_messages(features: &HashMap<u32, tonic_lnd::lnrpc::Feature>) -> bool {
     features.contains_key(&ONION_MESSAGES_OPTIONAL)
         || features.contains_key(&ONION_MESSAGES_REQUIRED)

--- a/src/lndk_offers.rs
+++ b/src/lndk_offers.rs
@@ -102,9 +102,9 @@ impl OfferHandler {
     ) -> Result<u64, OfferError<bitcoin::secp256k1::Error>> {
         let validated_amount = validate_amount(&cfg.offer, cfg.amount).await?;
 
-        // For now we connect directly to the introduction node of the blinded path so we don't need any
-        // intermediate nodes here. In the future we'll query for a full path to the introduction node for
-        // better sender privacy.
+        // For now we connect directly to the introduction node of the blinded path so we don't need
+        // any intermediate nodes here. In the future we'll query for a full path to the
+        // introduction node for better sender privacy.
         match cfg.destination {
             Destination::Node(pubkey) => connect_to_peer(cfg.client.clone(), pubkey).await?,
             Destination::BlindedPath(ref path) => {
@@ -157,7 +157,8 @@ impl OfferHandler {
         Ok(validated_amount)
     }
 
-    // create_invoice_request builds and signs an invoice request, the first step in the BOLT 12 process of paying an offer.
+    // create_invoice_request builds and signs an invoice request, the first step in the BOLT 12
+    // process of paying an offer.
     pub async fn create_invoice_request(
         &self,
         mut signer: impl MessageSigner + std::marker::Send + 'static,
@@ -182,10 +183,10 @@ impl OfferHandler {
 
         // Generate a new payment id for this payment.
         let bytes = self.messenger_utils.get_secure_random_bytes();
-        // We need to add some metadata to the invoice request to help with verification of the invoice
-        // once returned from the offer maker. Once we get an invoice back, this metadata will help us
-        // to determine: 1) That the invoice is truly for the invoice request we sent. 2) We don't pay
-        // duplicate invoices.
+        // We need to add some metadata to the invoice request to help with verification of the
+        // invoice once returned from the offer maker. Once we get an invoice back, this
+        // metadata will help us to determine: 1) That the invoice is truly for the invoice
+        // request we sent. 2) We don't pay duplicate invoices.
         let unsigned_invoice_req = offer
             .request_invoice_deriving_metadata(
                 pubkey,

--- a/src/onion_messenger.rs
+++ b/src/onion_messenger.rs
@@ -75,7 +75,6 @@ impl EntropySource for MessengerUtilities {
 
 impl Logger for MessengerUtilities {
     fn log(&self, record: Record) {
-        //println!("ARE WE GETTING ANY LDK LOGS??? {record:?}");
         let args_str = record.args.to_string();
         match record.level {
             Level::Gossip => {}

--- a/src/onion_messenger.rs
+++ b/src/onion_messenger.rs
@@ -47,8 +47,8 @@ const DEFAULT_CALL_COUNT: u8 = 10;
 /// DEFAULT_CALL_FREQUENCY is the default period over which peers are rate limited.
 const DEFAULT_CALL_FREQUENCY: Duration = Duration::from_secs(1);
 
-/// MessengerUtilities is a utility struct used to provide Logger and EntropySource trait implementations for LDK’s
-/// OnionMessenger.
+/// MessengerUtilities is a utility struct used to provide Logger and EntropySource trait
+/// implementations for LDK’s OnionMessenger.
 pub struct MessengerUtilities {}
 
 impl MessengerUtilities {
@@ -89,17 +89,22 @@ impl Logger for MessengerUtilities {
 }
 
 impl LndkOnionMessenger {
-    /// run_onion_messenger is the main event loop for connecting an OnionMessenger to LND's various APIs to handle
-    /// onion messages externally to LND. It follows a producer / consumer pattern, with many producers
-    /// creating MessengerEvents that are handled by a single consumer that drives the OnionMessenger accordingly. This
-    /// function will block until consumer errors or one of the producers exits.
+    /// run_onion_messenger is the main event loop for connecting an OnionMessenger to LND's various
+    /// APIs to handle onion messages externally to LND. It follows a producer / consumer
+    /// pattern, with many producers creating MessengerEvents that are handled by a single
+    /// consumer that drives the OnionMessenger accordingly. This function will block until
+    /// consumer errors or one of the producers exits.
     ///
     /// Producers:
-    /// 1. Peer Events: Sourced from LND's PeerEventSubscription API, produces peer online and offline events.
-    /// 2. Incoming Messages: Sourced from LND's SubscribeCustomMessages API, produces incoming onion message events.
-    /// 3. Outgoing Poll: Using a simple ticker, produces polling events to check for outgoing onion messages.
+    /// 1. Peer Events: Sourced from LND's PeerEventSubscription API, produces peer online and
+    ///    offline events.
+    /// 2. Incoming Messages: Sourced from LND's SubscribeCustomMessages API, produces incoming
+    ///    onion message events.
+    /// 3. Outgoing Poll: Using a simple ticker, produces polling events to check for outgoing onion
+    ///    messages.
     ///
-    /// The main consumer processes one MessengerEvent at a time, applying basic rate limiting to each peer to prevent spam.
+    /// The main consumer processes one MessengerEvent at a time, applying basic rate limiting to
+    /// each peer to prevent spam.
     pub(crate) async fn run_onion_messenger<
         ES: Deref,
         NS: Deref,
@@ -123,10 +128,12 @@ impl LndkOnionMessenger {
         OMH::Target: OffersMessageHandler,
         CMH::Target: CustomOnionMessageHandler + Sized,
     {
-        // Setup channels that we'll use to communicate onion messenger events. We buffer our channels by the number of
-        // peers (+1 because we require a non-zero buffer) that the node currently has so that we can send all of our
-        // startup online events in one go (before we boot up the consumer). The number of peers that we have is also
-        // related to the number of events we can expect to process, so it's a sensible enough buffer size.
+        // Setup channels that we'll use to communicate onion messenger events. We buffer our
+        // channels by the number of peers (+1 because we require a non-zero buffer) that
+        // the node currently has so that we can send all of our startup online events in
+        // one go (before we boot up the consumer). The number of peers that we have is also
+        // related to the number of events we can expect to process, so it's a sensible enough
+        // buffer size.
         let (sender, receiver) = channel(current_peers.len() + 1);
         for (peer, onion_support) in current_peers.clone() {
             sender
@@ -139,9 +146,10 @@ impl LndkOnionMessenger {
 
         let mut set = tokio::task::JoinSet::new();
 
-        // Subscribe to peer events from LND first thing so that we don't miss any online/offline events while we are
-        // starting up. The onion messenger can handle superfluous online/offline reports, so it's okay if this ends
-        // up creating some duplicate events. The event subscription from LND blocks until it gets its first event (which
+        // Subscribe to peer events from LND first thing so that we don't miss any online/offline
+        // events while we are starting up. The onion messenger can handle superfluous
+        // online/offline reports, so it's okay if this ends up creating some duplicate
+        // events. The event subscription from LND blocks until it gets its first event (which
         // could take very long), so we get the subscription itself inside of our producer thread.
         let mut peers_client = ln_client.clone();
         let peers_sender = sender.clone();
@@ -194,8 +202,8 @@ impl LndkOnionMessenger {
             }
         });
 
-        // Spin up a ticker that polls at an interval for any outgoing messages so that we can pass on outgoing messages to
-        // LND.
+        // Spin up a ticker that polls at an interval for any outgoing messages so that we can pass
+        // on outgoing messages to LND.
         let interval = time::interval(MSG_POLL_INTERVAL);
         let (events_shutdown, events_listener) =
             (signals.shutdown.clone(), signals.listener.clone());
@@ -209,9 +217,10 @@ impl LndkOnionMessenger {
             }
         });
 
-        // Consume events is our main controlling loop, so we run it inline here. We use a RefCell in onion_messenger to
-        // allow interior mutability (see LndNodeSigner) so this function can't safely be passed off to another thread.
-        // This function is expected to finish if any producing thread exits (because we're no longer receiving the
+        // Consume events is our main controlling loop, so we run it inline here. We use a RefCell
+        // in onion_messenger to allow interior mutability (see LndNodeSigner) so this
+        // function can't safely be passed off to another thread. This function is expected
+        // to finish if any producing thread exits (because we're no longer receiving the
         // events we need).
         let rate_limiter = &mut TokenLimiter::new(
             current_peers.keys().copied(),
@@ -258,9 +267,9 @@ impl LndkOnionMessenger {
     }
 }
 
-/// lookup_onion_support performs a best-effort lookup in the node's list of current peers to determine whether it
-/// supports onion messaging. If the node is not found a warning is logged and we assume that onion messaging is not
-/// supported.
+/// lookup_onion_support performs a best-effort lookup in the node's list of current peers to
+/// determine whether it supports onion messaging. If the node is not found a warning is logged and
+/// we assume that onion messaging is not supported.
 async fn lookup_onion_support(pubkey: &PublicKey, client: &mut tonic_lnd::LightningClient) -> bool {
     match client
         .list_peers(tonic_lnd::lnrpc::ListPeersRequest {
@@ -290,9 +299,11 @@ async fn lookup_onion_support(pubkey: &PublicKey, client: &mut tonic_lnd::Lightn
 #[derive(Debug)]
 /// ProducerError represents the exit of a producing loop.
 enum ProducerError {
-    /// SendError indicates that a producer could not send a messenger event, likely due to consumer shutdown.
+    /// SendError indicates that a producer could not send a messenger event, likely due to
+    /// consumer shutdown.
     SendError(String),
-    /// StreamError indicates that LND's stream has terminated, either due to error or shutdown of the underlying node.
+    /// StreamError indicates that LND's stream has terminated, either due to error or shutdown of
+    /// the underlying node.
     StreamError(String),
 }
 
@@ -333,13 +344,14 @@ impl PeerEventProducer for PeerStream {
     }
 }
 
-/// Consumes a stream of peer online/offline events from the PeerEventProducer until the stream exits (by sending an
-/// error) or the producer receives the signal to exit (via close of the exit channel).
+/// Consumes a stream of peer online/offline events from the PeerEventProducer until the stream
+/// exits (by sending an error) or the producer receives the signal to exit (via close of the exit
+/// channel).
 ///
-/// Note that this function *must* send an exit error to the Sender provided on all exit-cases, so that upstream
-/// consumers know to exit as well. Failures related to sending events are an exception, as failure to send indicates
-/// that the consumer has already exited (the receiving end of the channel has hung up), and we can't send any more
-/// events anyway.
+/// Note that this function *must* send an exit error to the Sender provided on all exit-cases, so
+/// that upstream consumers know to exit as well. Failures related to sending events are an
+/// exception, as failure to send indicates that the consumer has already exited (the receiving end
+/// of the channel has hung up), and we can't send any more events anyway.
 async fn produce_peer_events(
     mut source: impl PeerEventProducer,
     events: Sender<MessengerEvents>,
@@ -396,8 +408,8 @@ async fn produce_peer_events(
 }
 
 #[async_trait]
-/// IncomingMessageProducer prodices a layer of abstraction over LND's custom messaging subscription for incoming
-/// messages.
+/// IncomingMessageProducer prodices a layer of abstraction over LND's custom messaging subscription
+/// for incoming messages.
 trait IncomingMessageProducer {
     async fn receive(&mut self) -> Result<CustomMessage, Status>;
 }
@@ -416,13 +428,14 @@ impl IncomingMessageProducer for MessageStream {
     }
 }
 
-/// Consumes a stream of incoming message events from the IncomingMessageProducer until the stream exits (by sending an
-/// error) or the producer receives the signal to exit (via close of the exit channel).
+/// Consumes a stream of incoming message events from the IncomingMessageProducer until the stream
+/// exits (by sending an error) or the producer receives the signal to exit (via close of the exit
+/// channel).
 ///
-/// Note that this function *must* send an exit error to the Sender provided on all exit-cases, so that upstream
-/// consumers know to exit as well. Failures related to sending events are an exception, as failure to send indicates
-/// that the consumer has already exited (the receiving end of the channel has hung up), and we can't send any more
-/// events anyway.
+/// Note that this function *must* send an exit error to the Sender provided on all exit-cases, so
+/// that upstream consumers know to exit as well. Failures related to sending events are an
+/// exception, as failure to send indicates that the consumer has already exited (the receiving end
+/// of the channel has hung up), and we can't send any more events anyway.
 async fn produce_incoming_message_events(
     mut source: impl IncomingMessageProducer,
     events: Sender<MessengerEvents>,
@@ -537,8 +550,8 @@ impl fmt::Display for MessengerEvents {
     }
 }
 
-/// consume_messenger_events receives a series of onion messaging related events and delivers them to the
-/// OnionMessenger provided, using the RateLimiter to limit resources consumed by each peer.
+/// consume_messenger_events receives a series of onion messaging related events and delivers them
+/// to the OnionMessenger provided, using the RateLimiter to limit resources consumed by each peer.
 async fn consume_messenger_events(
     onion_messenger: impl OnionMessageHandler,
     mut events: Receiver<MessengerEvents>,
@@ -576,15 +589,17 @@ async fn consume_messenger_events(
                     )
                     .map_err(|_| ConsumerError::OnionMessengerFailure)?;
 
-                // In addition to keeping the onion messenger up to date with the latest peers, we need to keep our
-                // local version up to date so we send outgoing OMs all of our peers.
+                // In addition to keeping the onion messenger up to date with the latest peers, we
+                // need to keep our local version up to date so we send outgoing OMs
+                // all of our peers.
                 rate_limiter.peer_connected(pubkey);
             }
             MessengerEvents::PeerDisconnected(pubkey) => {
                 onion_messenger.peer_disconnected(&pubkey);
 
-                // In addition to keeping the onion messenger up to date with the latest peers, we need to keep our
-                // local version up to date so we send outgoing OMs to our correct peers.
+                // In addition to keeping the onion messenger up to date with the latest peers, we
+                // need to keep our local version up to date so we send outgoing OMs
+                // to our correct peers.
                 rate_limiter.peer_disconnected(pubkey);
             }
             MessengerEvents::IncomingMessage(pubkey, onion_message) => {
@@ -638,12 +653,13 @@ impl SendCustomMessage for CustomMessenger {
     }
 }
 
-/// produce_outgoing_message_events is produce for producing outgoing message events at a regular interval.
+/// produce_outgoing_message_events is produce for producing outgoing message events at a regular
+/// interval.
 ///
-/// Note that this function *must* send an exit error to the Sender provided on all exit-cases, so that upstream
-/// consumers know to exit as well. Failures related to sending events are an exception, as failure to send indicates
-/// that the consumer has already exited (the receiving end of the channel has hung up), and we can't send any more
-/// events anyway.
+/// Note that this function *must* send an exit error to the Sender provided on all exit-cases, so
+/// that upstream consumers know to exit as well. Failures related to sending events are an
+/// exception, as failure to send indicates that the consumer has already exited (the receiving end
+/// of the channel has hung up), and we can't send any more events anyway.
 async fn produce_outgoing_message_events(
     events: Sender<MessengerEvents>,
     listener: Listener,
@@ -671,8 +687,8 @@ async fn produce_outgoing_message_events(
     }
 }
 
-/// relay_outgoing_msg_event is responsible for passing along new outgoing messages from peers. If a new onion message
-/// turns up, it will pass it along to lnd.
+/// relay_outgoing_msg_event is responsible for passing along new outgoing messages from peers. If a
+/// new onion message turns up, it will pass it along to lnd.
 async fn relay_outgoing_msg_event(
     peer: &PublicKey,
     msg: OnionMessage,
@@ -717,9 +733,9 @@ mod tests {
     use std::io::Cursor;
     use tokio::sync::mpsc::channel;
 
-    /// Produces an OnionMessage that can be used for tests. We need to manually write individual bytes because onion
-    /// messages in LDK can only be created using read/write impls that deal with raw bytes (since some other fields
-    /// are not public).
+    /// Produces an OnionMessage that can be used for tests. We need to manually write individual
+    /// bytes because onion messages in LDK can only be created using read/write impls that deal
+    /// with raw bytes (since some other fields are not public).
     fn onion_message() -> OnionMessage {
         let mut w = vec![];
         let pubkey_bytes = pubkey(0).serialize();
@@ -758,8 +774,8 @@ mod tests {
             }
     }
 
-    // Mockall can't automatically produce a mock for EventsProvider since mockall requires generic parameters be
-    // 'static. See: https://docs.rs/mockall/latest/mockall/#generic-traits-and-structs. So we add the trait to our
+    // Mockall can't automatically produce a mock for EventsProvider since mockall requires generic
+    // parameters be 'static. See: https://docs.rs/mockall/latest/mockall/#generic-traits-and-structs. So we add the trait to our
     // mock manually here.
     impl EventsProvider for MockOnionHandler {
         fn process_pending_events<H: Deref>(&self, _handler: H)
@@ -810,8 +826,8 @@ mod tests {
         let mut sender_mock = MockSendCustomMessenger::new();
         let mut rate_limiter = MockRateLimiter::new();
 
-        // Setup rate limiter to no-op on peer connected / disconnected calls (we have proper assertions for the onion
-        // messenger's calls anyway).
+        // Setup rate limiter to no-op on peer connected / disconnected calls (we have proper
+        // assertions for the onion messenger's calls anyway).
         rate_limiter.expect_peer_connected().returning(|_| {});
         rate_limiter.expect_peer_disconnected().returning(|_| {});
 
@@ -1110,8 +1126,8 @@ mod tests {
         let (shutdown, listener) = triggered::trigger();
         let interval = time::interval(MSG_POLL_INTERVAL);
 
-        // Let's test that produce_outgoing_message_events successfully exits when it receives the signal, rather than
-        // loop infinitely.
+        // Let's test that produce_outgoing_message_events successfully exits when it receives the
+        // signal, rather than loop infinitely.
         shutdown.trigger();
         assert!(produce_outgoing_message_events(sender, listener, interval)
             .await

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -187,8 +187,8 @@ impl LndNode {
         let cert_path = lnd_dir.to_str().unwrap().to_string() + "/tls.cert";
         let key_path = lnd_dir.to_str().unwrap().to_string() + "/tls.key";
 
-        // Have node run on a randomly assigned grpc port. That way, if we run more than one lnd node, they won't
-        // clash.
+        // Have node run on a randomly assigned grpc port. That way, if we run more than one lnd
+        // node, they won't clash.
         let port = bitcoind::get_available_port().unwrap();
         let rpc_addr = format!("localhost:{}", port);
         let lnd_port = bitcoind::get_available_port().unwrap();
@@ -243,7 +243,8 @@ impl LndNode {
 
     // Setup the client we need to interact with the LND node.
     async fn setup_client(&mut self) {
-        // We need to give lnd some time to start up before we'll be able to interact with it via the client.
+        // We need to give lnd some time to start up before we'll be able to interact with it via
+        // the client.
         let mut retry = false;
         let mut retry_num = 0;
         while retry_num == 0 || retry {

--- a/tests/common/test_utils.rs
+++ b/tests/common/test_utils.rs
@@ -4,10 +4,11 @@ use std::ops::FnMut;
 use tokio::time::{sleep, Duration};
 use tonic_lnd::tonic::{Response, Status};
 
-// If a grpc call returns an error, retry_async will retry the grpc function call in case lnd is still in
-// the process of starting up. A note on implementation: We can't pass in a future directly to a function
-// because futures cannot be cloned/copied in order to retry the future. Instead retry_async takes in an
-// async closure that is able to "copy" the function for us so we can call it multiple times for retries.
+// If a grpc call returns an error, retry_async will retry the grpc function call in case lnd is
+// still in the process of starting up. A note on implementation: We can't pass in a future directly
+// to a function because futures cannot be cloned/copied in order to retry the future. Instead
+// retry_async takes in an async closure that is able to "copy" the function for us so we can call
+// it multiple times for retries.
 pub(crate) async fn retry_async<F, Fut, D>(mut f: F, func_name: String) -> Result<D, ()>
 where
     F: FnMut() -> Fut + std::marker::Copy,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -56,7 +56,8 @@ async fn test_lndk_forwards_onion_message() {
     let (_bitcoind, mut lnd, ldk1, ldk2, lndk_dir) =
         common::setup_test_infrastructure(test_name).await;
 
-    // Here we'll produce a little path of two channels. Both ldk nodes are connected to lnd like so:
+    // Here we'll produce a little path of two channels. Both ldk nodes are connected to lnd like
+    // so:
     //
     // ldk1 <-> lnd <-> ldk2
     //
@@ -67,8 +68,8 @@ async fn test_lndk_forwards_onion_message() {
     lnd.connect_to_peer(pubkey_2, addr_2).await;
     let lnd_info = lnd.get_info().await;
 
-    // Now we'll spin up lndk. Even though ldk1 and ldk2 are not directly connected, we'll show that lndk
-    // successfully helps lnd forward the onion message from ldk1 to ldk2.
+    // Now we'll spin up lndk. Even though ldk1 and ldk2 are not directly connected, we'll show that
+    // lndk successfully helps lnd forward the onion message from ldk1 to ldk2.
     let (shutdown, listener) = triggered::trigger();
 
     let creds = validate_lnd_creds(
@@ -264,8 +265,8 @@ async fn test_lndk_send_invoice_request() {
         }
     }
 
-    // Let's try again, but, make sure we can request the invoice when the LND node is not already connected
-    // to the introduction node (LDK2).
+    // Let's try again, but, make sure we can request the invoice when the LND node is not already
+    // connected to the introduction node (LDK2).
     lnd.disconnect_peer(pubkey_2).await;
     lnd.wait_for_chain_sync().await;
 


### PR DESCRIPTION
Throughout lndk the comment lengths are all over the place. This PR establishes a standard comment length maximum of 100, which is the same max line length as the rest of the code. The PR also updates the github workflows to enforce this new standard.

Contributors now will need to run `cargo fmt -- --config unstable_features=true --config wrap_comments=true --config comment_width=100` to make sure comments meet this restriction.

We also sneak in a couple other fixes in this PR:
- Update codecov-actions to v4 to fix #114
- Add .vscode to .gitignore