### PR TITLE
offers: various small fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,10 +264,10 @@ impl OfferHandler {
             e
         })?;
 
-        let invoice = match timeout(Duration::from_secs(100), self.wait_for_invoice()).await {
+        let invoice = match timeout(Duration::from_secs(20), self.wait_for_invoice()).await {
             Ok(invoice) => invoice,
             Err(_) => {
-                error!("Did not receive invoice in 100 seconds.");
+                error!("Did not receive invoice in 20 seconds.");
                 let mut active_offers = self.active_offers.lock().unwrap();
                 active_offers.remove(&offer_id.clone());
                 return Err(OfferError::InvoiceTimeout);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,13 +341,17 @@ impl OffersMessageHandler for OfferHandler {
                     // for this payment. Right now it's safe to let this be because we won't try to
                     // pay a second invoice (if it comes through).
                     Ok(_payment_id) => {
+                        info!("Received an invoice: {invoice:?}");
                         let mut active_invoices = self.active_invoices.lock().unwrap();
                         active_invoices.push(invoice.clone());
                         Some(OffersMessage::Invoice(invoice))
                     }
-                    Err(()) => Some(OffersMessage::InvoiceError(InvoiceError::from_string(
-                        String::from("invoice verification failure"),
-                    ))),
+                    Err(()) => {
+                        error!("Invoice verification failed for invoice: {invoice:?}");
+                        Some(OffersMessage::InvoiceError(InvoiceError::from_string(
+                            String::from("invoice verification failure"),
+                        )))
+                    }
                 }
             }
             OffersMessage::InvoiceError(error) => {

--- a/src/lndk_offers.rs
+++ b/src/lndk_offers.rs
@@ -624,8 +624,12 @@ mod tests {
             .unwrap()
     }
 
-    fn get_pubkey() -> String {
-        "0313ba7ccbd754c117962b9afab6c2870eb3ef43f364a9f6c43d0fabb4553776ba".to_string()
+    fn get_pubkey() -> Vec<String> {
+        let pubkey1 =
+            "0313ba7ccbd754c117962b9afab6c2870eb3ef43f364a9f6c43d0fabb4553776ba".to_string();
+        let pubkey2 =
+            "03b060a3b572ab060532fbe49506fe25b5957195733788aab01ab3c0f40bb52602".to_string();
+        vec![pubkey1, pubkey2]
     }
 
     fn get_invoice_request(offer: Offer, amount: u64) -> InvoiceRequest {
@@ -651,7 +655,7 @@ mod tests {
         let entropy_source = MessengerUtilities::new();
         let secp_ctx = Secp256k1::new();
         BlindedPath::new_for_message(
-            &[PublicKey::from_str(&get_pubkey()).unwrap()],
+            &[PublicKey::from_str(&get_pubkey()[0]).unwrap()],
             &entropy_source,
             &secp_ctx,
         )
@@ -696,7 +700,7 @@ mod tests {
         let mut signer_mock = MockTestBolt12Signer::new();
 
         signer_mock.expect_derive_key().returning(|_| {
-            let pubkey = PublicKey::from_str(&get_pubkey()).unwrap();
+            let pubkey = PublicKey::from_str(&get_pubkey()[0]).unwrap();
             Ok(pubkey.serialize().to_vec())
         });
 
@@ -744,7 +748,7 @@ mod tests {
         let mut signer_mock = MockTestBolt12Signer::new();
 
         signer_mock.expect_derive_key().returning(|_| {
-            Ok(PublicKey::from_str(&get_pubkey())
+            Ok(PublicKey::from_str(&get_pubkey()[0])
                 .unwrap()
                 .serialize()
                 .to_vec())
@@ -812,7 +816,7 @@ mod tests {
             .expect_connect_peer()
             .returning(|_, _| Ok(()));
 
-        let pubkey = PublicKey::from_str(&get_pubkey()).unwrap();
+        let pubkey = PublicKey::from_str(&get_pubkey()[0]).unwrap();
         assert!(connect_to_peer(connector_mock, pubkey).await.is_ok());
     }
 
@@ -821,7 +825,7 @@ mod tests {
         let mut connector_mock = MockTestPeerConnector::new();
         connector_mock.expect_list_peers().returning(|| {
             let peer = tonic_lnd::lnrpc::Peer {
-                pub_key: get_pubkey(),
+                pub_key: get_pubkey()[0].clone(),
                 ..Default::default()
             };
 
@@ -844,7 +848,7 @@ mod tests {
             Ok(Some(node))
         });
 
-        let pubkey = PublicKey::from_str(&get_pubkey()).unwrap();
+        let pubkey = PublicKey::from_str(&get_pubkey()[0]).unwrap();
         assert!(connect_to_peer(connector_mock, pubkey).await.is_ok());
     }
 
@@ -874,7 +878,7 @@ mod tests {
             .expect_connect_peer()
             .returning(|_, _| Err(Status::unknown("")));
 
-        let pubkey = PublicKey::from_str(&get_pubkey()).unwrap();
+        let pubkey = PublicKey::from_str(&get_pubkey()[0]).unwrap();
         assert!(connect_to_peer(connector_mock, pubkey).await.is_err());
     }
 
@@ -890,14 +894,14 @@ mod tests {
             feature_entry.insert(38, feature);
 
             let peer = tonic_lnd::lnrpc::Peer {
-                pub_key: get_pubkey(),
+                pub_key: get_pubkey()[0].clone(),
                 features: feature_entry,
                 ..Default::default()
             };
             Ok(ListPeersResponse { peers: vec![peer] })
         });
 
-        let receiver_node_id = PublicKey::from_str(&get_pubkey()).unwrap();
+        let receiver_node_id = PublicKey::from_str(&get_pubkey()[0]).unwrap();
         let handler = OfferHandler::new();
         assert!(handler
             .create_reply_path(connector_mock, receiver_node_id)
@@ -914,7 +918,7 @@ mod tests {
             .expect_list_peers()
             .returning(|| Ok(ListPeersResponse { peers: vec![] }));
 
-        let receiver_node_id = PublicKey::from_str(&get_pubkey()).unwrap();
+        let receiver_node_id = PublicKey::from_str(&get_pubkey()[0]).unwrap();
         let handler = OfferHandler::new();
         assert!(handler
             .create_reply_path(connector_mock, receiver_node_id)
@@ -930,7 +934,7 @@ mod tests {
             .expect_list_peers()
             .returning(|| Err(Status::unknown("unknown error")));
 
-        let receiver_node_id = PublicKey::from_str(&get_pubkey()).unwrap();
+        let receiver_node_id = PublicKey::from_str(&get_pubkey()[0]).unwrap();
         let handler = OfferHandler::new();
         assert!(handler
             .create_reply_path(connector_mock, receiver_node_id)

--- a/src/server.rs
+++ b/src/server.rs
@@ -63,7 +63,7 @@ impl Offers for LNDKServer {
         let destination = get_destination(&offer).await;
         let reply_path = match self
             .offer_handler
-            .create_reply_path(client.clone(), self.node_id)
+            .create_reply_path(client.clone(), self.node_id, offer.signing_pubkey())
             .await
         {
             Ok(reply_path) => reply_path,


### PR DESCRIPTION
This PR fixes a few things:
- When choosing an introduction node for a reply path for an invoice request, we now exclude the node we're making a payment to as an introduction node option. I'm still thinking about whether this is the best approach, or whether it fully makes sense, but at least (for now) it seems to fix a problem when sending payments to CLN. If we send CLN an invoice request where the introduction node of the reply path *is* the CLN node, CLN is unsure how to respond and, well, doesn't respond.
- Improves logs when we've received an invoice or when attempting to verify an invoice results in an error.
- Lowers the timeout period for waiting for an invoice to come back. Though we should probably make this configurable at some point...