### PR TITLE
logs: add ldk sublogger

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub fn init_logger(config: LogConfig) {
 
 pub const DEFAULT_SERVER_HOST: &str = "127.0.0.1";
 pub const DEFAULT_SERVER_PORT: u16 = 7000;
+pub const LDK_LOGGER_NAME: &str = "ldk";
 
 #[allow(clippy::result_unit_err)]
 pub fn setup_logger(log_level: Option<String>, log_dir: Option<String>) -> Result<(), ()> {
@@ -98,6 +99,7 @@ pub fn setup_logger(log_level: Option<String>, log_dir: Option<String>) -> Resul
         .logger(Logger::builder().build("rustls", LevelFilter::Info))
         .logger(Logger::builder().build("tokio_util", LevelFilter::Info))
         .logger(Logger::builder().build("tracing", LevelFilter::Info))
+        .logger(Logger::builder().build(LDK_LOGGER_NAME, log_level))
         .build(
             Root::builder()
                 .appender("stdout")

--- a/src/onion_messenger.rs
+++ b/src/onion_messenger.rs
@@ -1,7 +1,7 @@
 use crate::clock::TokioClock;
 use crate::lnd::{features_support_onion_messages, ONION_MESSAGES_OPTIONAL};
 use crate::rate_limit::{RateLimiter, TokenLimiter};
-use crate::{LifecycleSignals, LndkOnionMessenger};
+use crate::{LifecycleSignals, LndkOnionMessenger, LDK_LOGGER_NAME};
 use async_trait::async_trait;
 use bitcoin::blockdata::constants::ChainHash;
 use bitcoin::network::constants::Network;
@@ -78,11 +78,11 @@ impl Logger for MessengerUtilities {
         let args_str = record.args.to_string();
         match record.level {
             Level::Gossip => {}
-            Level::Trace => trace!("{}", args_str),
-            Level::Debug => debug!("{}", args_str),
-            Level::Info => info!("{}", args_str),
-            Level::Warn => warn!("{}", args_str),
-            Level::Error => error!("{}", args_str),
+            Level::Trace => trace!(target: LDK_LOGGER_NAME, "{}", args_str),
+            Level::Debug => debug!(target: LDK_LOGGER_NAME, "{}", args_str),
+            Level::Info => info!(target: LDK_LOGGER_NAME, "{}", args_str),
+            Level::Warn => warn!(target: LDK_LOGGER_NAME, "{}", args_str),
+            Level::Error => error!(target: LDK_LOGGER_NAME, "{}", args_str),
         }
     }
 }


### PR DESCRIPTION
This PR implements solution to #28:
- Adds a sublogger (or subsystem logger) LDK
- Then target that sublogger on MessageInstance

I tried adding just the prefix `ldk: {}` but it didn't feel right.

**Few examples**

Current log
`2024-06-10T19:02:45.197452-04:00 TRACE lndk::onion_messenger - Missing reply path when responding to Offers onion message with path_id None`

Only prefix:
`2024-06-10T19:02:45.197452-04:00 TRACE lndk::onion_messenger - ldk: Missing reply path when responding to Offers onion message with path_id None`

With subsystem (this PR)
`2024-06-10T19:20:58.794410-04:00 TRACE ldk - Missing reply path when responding to Offers onion message with path_id None`

