### PR TITLE
Fix peer connect race

### DIFF
--- a/src/onion_messenger.rs
+++ b/src/onion_messenger.rs
@@ -29,7 +29,8 @@ use std::io::Cursor;
 use std::marker::Copy;
 use std::str::FromStr;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
-use tokio::{select, time, time::Duration, time::Interval};
+use tokio::time::{sleep, timeout, Duration, Interval};
+use tokio::{select, time};
 use tonic_lnd::lnrpc::ChanInfoRequest;
 use tonic_lnd::Client;
 use tonic_lnd::{
@@ -331,7 +332,26 @@ async fn lookup_onion_support(pubkey: &PublicKey, client: &mut tonic_lnd::Lightn
                     continue;
                 }
 
-                return features_support_onion_messages(&peer.features);
+                // Sometimes if the connection to the peer is very new, we have to wait for the
+                // features map to populate as non-empty.
+                let check_empty_timeout = 5;
+                let features = match timeout(
+                    Duration::from_secs(check_empty_timeout),
+                    check_empty_features(pubkey, client.clone()),
+                )
+                .await
+                {
+                    Ok(features) => features,
+                    Err(_) => {
+                        warn!(
+                            "Did not get non-empty feature set from peer {} set in {} seconds.",
+                            peer.pub_key, check_empty_timeout
+                        );
+                        peer.features
+                    }
+                };
+
+                return features_support_onion_messages(&features);
             }
 
             warn!("Peer {pubkey} not found in current set of peers, assuming no onion support.");
@@ -341,6 +361,39 @@ async fn lookup_onion_support(pubkey: &PublicKey, client: &mut tonic_lnd::Lightn
             warn!("Could not lookup peers for {pubkey}: {e}, assuming no onion message support.");
             false
         }
+    }
+}
+
+// check_empty_features repeatedly looks up the peer's feature set until it returns a non-empty
+// map. Sometimes if a peer is new, LND needs a little time to update the feature set.
+async fn check_empty_features(
+    pubkey: &PublicKey,
+    mut client: LightningClient,
+) -> HashMap<u32, tonic_lnd::lnrpc::Feature> {
+    loop {
+        match client
+            .list_peers(tonic_lnd::lnrpc::ListPeersRequest {
+                latest_error: false,
+            })
+            .await
+        {
+            Ok(peers) => {
+                for peer in peers.into_inner().peers {
+                    if peer.pub_key != pubkey.to_string() {
+                        continue;
+                    }
+
+                    if !peer.features.is_empty() {
+                        return peer.features;
+                    }
+                }
+            }
+            Err(_) => {
+                warn!("error connecting to listpeers");
+                continue;
+            }
+        };
+        sleep(Duration::from_millis(500)).await;
     }
 }
 


### PR DESCRIPTION
This PR tackles an issue that has popped up in bolt12-playground when paying Eclair offers.

If we need to connect directly to the introduction node, LNDK's onion messenger receives a PeerConnected event to process this new connection. When we first look at that new peer, the features map is empty, and LNDK decides onion support must be "false". This messes up future payment attempts, because the onion messenger thinks that this peer doesn't support onion messaging, and shouldn't be considered in future payment paths. To fix this, the first commit adds a little wait loop that looks for a non-empty map.