### PR TITLE
server: get_invoice and pay_offer endpoints

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -18,14 +18,20 @@ A cli for interacting with lndk
 Usage: lndk-cli [OPTIONS] <COMMAND>
 
 Commands:
-  decode     Decodes a bech32-encoded offer string into a BOLT 12 offer
-  pay-offer  PayOffer pays a BOLT 12 offer, provided as a 'lno'-prefaced offer string
-  help       Print this message or the help of the given subcommand(s)
+  decode-offer    Decodes a bech32-encoded offer string into a BOLT 12 offer
+  decode-invoice  Decodes a bech32-encoded invoice string into a BOLT 12 invoice
+  pay-offer       PayOffer pays a BOLT 12 offer, provided as a 'lno'-prefaced offer string
+  get-invoice     GetInvoice fetch a BOLT 12 invoice, which will be returned as a hex-encoded string. It fetches the invoice from a BOLT 12 offer, provided as a 'lno'-prefaced offer string
+  pay-invoice     PayInvoice pays a hex-encoded BOLT12 invoice
+  help            Print this message or the help of the given subcommand(s)
 
 Options:
-  -n, --network <NETWORK>              Global variables [default: regtest]          
-  -m, --macaroon-path <MACAROON_PATH>           
-      --macaroon-hex <MACAROON_HEX>    
+  -n, --network <NETWORK>              Global variables [default: regtest]
+  -m, --macaroon-path <MACAROON_PATH>  
+      --macaroon-hex <MACAROON_HEX>    A hex-encoded macaroon string to pass in directly to the cli
+      --cert-pem <CERT_PEM>            This option is for passing a pem-encoded TLS certificate string to establish a connection with the LNDK server. If this isn't set, the cli will look for the TLS file in the default location (~.lndk)
+      --grpc-host <GRPC_HOST>          [default: https://127.0.0.1]
+      --grpc-port <GRPC_PORT>          [default: 7000]
   -h, --help                           Print help
 ```
 

--- a/proto/lndkrpc.proto
+++ b/proto/lndkrpc.proto
@@ -22,7 +22,8 @@ message GetInvoiceRequest {
 }
 
 message GetInvoiceResponse {
-    string invoice = 1;
+    string invoice_hex_str = 1;
+    Bolt12InvoiceContents invoice_contents = 2;
 }
 
 message PayInvoiceRequest {
@@ -32,4 +33,96 @@ message PayInvoiceRequest {
 
 message PayInvoiceResponse {
     string payment_preimage = 1;
+}
+
+message Bolt12InvoiceContents {
+    string chain = 1;
+    optional uint64 quantity = 2;
+    uint64 amount_msats = 3;
+    optional string description = 4;
+    PaymentHash payment_hash = 5;
+    repeated PaymentPaths payment_paths = 6;
+    int64 created_at = 7;
+    uint64 relative_expiry = 8;
+    PublicKey node_id = 9;
+    string signature = 10;
+    repeated FeatureBit features = 11;
+}
+
+message PaymentHash {
+    bytes hash = 1;
+}
+
+message PublicKey {
+    bytes key = 1;
+}
+
+message BlindedPayInfo {
+    uint32 fee_base_msat = 1;
+    uint32 fee_proportional_millionths = 2;
+    uint32 cltv_expiry_delta = 3;
+    uint64 htlc_minimum_msat = 4;
+    uint64 htlc_maximum_msat = 5;
+    repeated FeatureBit features = 6;
+}
+
+message BlindedHop {
+    PublicKey blinded_node_id = 1;
+    bytes encrypted_payload = 2;
+}
+
+message BlindedPath {
+    IntroductionNode introduction_node = 1;
+    PublicKey blinding_point = 2;
+    repeated BlindedHop blinded_hops = 3;
+}
+
+message PaymentPaths {
+    BlindedPayInfo blinded_pay_info = 1;
+    BlindedPath blinded_path = 2;
+}
+
+message IntroductionNode {
+    optional PublicKey node_id = 1;
+    optional DirectedShortChannelId directed_short_channel_id = 2;
+}
+
+message DirectedShortChannelId {
+    Direction direction = 1;
+    uint64 scid = 2;
+}
+
+enum Direction {
+    NODE_ONE = 0;
+    NODE_TWO = 1;
+}
+
+enum FeatureBit {
+    DATALOSS_PROTECT_REQ = 0;
+    DATALOSS_PROTECT_OPT = 1;
+    INITIAL_ROUING_SYNC = 3;
+    UPFRONT_SHUTDOWN_SCRIPT_REQ = 4;
+    UPFRONT_SHUTDOWN_SCRIPT_OPT = 5;
+    GOSSIP_QUERIES_REQ = 6;
+    GOSSIP_QUERIES_OPT = 7;
+    TLV_ONION_REQ = 8;
+    TLV_ONION_OPT = 9;
+    EXT_GOSSIP_QUERIES_REQ = 10;
+    EXT_GOSSIP_QUERIES_OPT = 11;
+    STATIC_REMOTE_KEY_REQ = 12;
+    STATIC_REMOTE_KEY_OPT = 13;
+    PAYMENT_ADDR_REQ = 14;
+    PAYMENT_ADDR_OPT = 15;
+    MPP_REQ = 16;
+    MPP_OPT = 17;
+    WUMBO_CHANNELS_REQ = 18;
+    WUMBO_CHANNELS_OPT = 19;
+    ANCHORS_REQ = 20;
+    ANCHORS_OPT = 21;
+    ANCHORS_ZERO_FEE_HTLC_REQ = 22;
+    ANCHORS_ZERO_FEE_HTLC_OPT = 23;
+    ROUTE_BLINDING_REQUIRED = 24;
+    ROUTE_BLINDING_OPTIONAL = 25;
+    AMP_REQ = 30;
+    AMP_OPT = 31;
 }

--- a/proto/lndkrpc.proto
+++ b/proto/lndkrpc.proto
@@ -3,6 +3,8 @@ package lndkrpc;
 
 service Offers {
     rpc PayOffer (PayOfferRequest) returns (PayOfferResponse);
+    rpc GetInvoice (GetInvoiceRequest) returns (GetInvoiceResponse);
+    rpc PayInvoice (PayInvoiceRequest) returns (PayInvoiceResponse);
 }
 
 message PayOfferRequest {
@@ -12,4 +14,22 @@ message PayOfferRequest {
 
 message PayOfferResponse {
     string payment_preimage = 2;
+}
+
+message GetInvoiceRequest {
+    string offer = 1;
+    optional uint64 amount = 2;
+}
+
+message GetInvoiceResponse {
+    string invoice = 1;
+}
+
+message PayInvoiceRequest {
+    string invoice = 1;
+    optional uint64 amount = 2;
+}
+
+message PayInvoiceResponse {
+    string payment_preimage = 1;
 }

--- a/proto/lndkrpc.proto
+++ b/proto/lndkrpc.proto
@@ -4,6 +4,7 @@ package lndkrpc;
 service Offers {
     rpc PayOffer (PayOfferRequest) returns (PayOfferResponse);
     rpc GetInvoice (GetInvoiceRequest) returns (GetInvoiceResponse);
+    rpc DecodeInvoice (DecodeInvoiceRequest) returns (Bolt12InvoiceContents);
     rpc PayInvoice (PayInvoiceRequest) returns (PayInvoiceResponse);
 }
 
@@ -19,6 +20,10 @@ message PayOfferResponse {
 message GetInvoiceRequest {
     string offer = 1;
     optional uint64 amount = 2;
+}
+
+message DecodeInvoiceRequest {
+    string invoice = 1;
 }
 
 message GetInvoiceResponse {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 use lndk::lndk_offers::decode;
 use lndk::lndkrpc::offers_client::OffersClient;
-use lndk::lndkrpc::PayOfferRequest;
+use lndk::lndkrpc::{GetInvoiceRequest, PayInvoiceRequest, PayOfferRequest};
 use lndk::{DEFAULT_DATA_DIR, DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT, TLS_CERT_FILENAME};
 use std::fs::File;
 use std::io::BufReader;
@@ -73,6 +73,25 @@ enum Commands {
         #[arg(required = false)]
         amount: Option<u64>,
     },
+    /// GetInvoice fetch a BOLT 12 invoice, which will be returned as a hex-encoded string. It
+    /// fetches the invoice from a BOLT 12 offer, provided as a 'lno'-prefaced offer string.
+    GetInvoice {
+        /// The offer string.
+        offer_string: String,
+        /// Amount the user would like to pay. If this isn't set, we'll assume the user is paying
+        /// whatever the offer amount is.
+        #[arg(required = false)]
+        amount: Option<u64>,
+    },
+    /// PayInvoice pays a hex-encoded BOLT12 invoice.
+    PayInvoice {
+        /// The hex-encoded invoice string.
+        invoice_string: String,
+        /// Amount the user would like to pay. If this isn't set, we'll assume the user is paying
+        /// whatever the invoice amount is set to.
+        #[arg(required = false)]
+        amount: Option<u64>,
+    },
 }
 
 #[tokio::main]
@@ -102,7 +121,7 @@ async fn main() {
             let tls = read_cert_from_args(&args);
             let grpc_host = args.grpc_host.clone();
             let grpc_port = args.grpc_port;
-            let channel = Channel::from_shared(format!("{grpc_host}:{grpc_port}")) //
+            let channel = Channel::from_shared(format!("{grpc_host}:{grpc_port}"))
                 .unwrap_or_else(|e| {
                     println!("ERROR creating endpoint: {e:?}");
                     exit(1)
@@ -148,10 +167,102 @@ async fn main() {
                 }
             };
         }
+        Commands::GetInvoice {
+            ref offer_string,
+            amount,
+        } => {
+            let tls = read_cert_from_args(&args);
+            let grpc_host = args.grpc_host.clone();
+            let grpc_port = args.grpc_port;
+            let channel = Channel::from_shared(format!("{grpc_host}:{grpc_port}"))
+                .unwrap_or_else(|e| {
+                    println!("ERROR creating endpoint: {e:?}");
+                    exit(1)
+                })
+                .tls_config(tls)
+                .unwrap_or_else(|e| {
+                    println!("ERROR tls config: {e:?}");
+                    exit(1)
+                })
+                .connect()
+                .await
+                .unwrap_or_else(|e| {
+                    println!("ERROR connecting: {e:?}");
+                    exit(1)
+                });
+
+            let mut client = OffersClient::new(channel);
+            let offer = match decode(offer_string.to_owned()) {
+                Ok(offer) => offer,
+                Err(e) => {
+                    println!(
+                        "ERROR: please provide offer starting with lno. Provided offer is \
+                        invalid, failed to decode with error: {:?}.",
+                        e
+                    );
+                    exit(1)
+                }
+            };
+
+            let macaroon = read_macaroon_from_args(&args);
+            let mut request = Request::new(GetInvoiceRequest {
+                offer: offer.to_string(),
+                amount,
+            });
+            add_metadata(&mut request, macaroon).unwrap_or_else(|_| exit(1));
+            match client.get_invoice(request).await {
+                Ok(response) => {
+                    println!("Invoice: {:?}.", response.get_ref())
+                }
+                Err(err) => {
+                    println!("Error getting invoice for offer: {err:?}");
+                    exit(1)
+                }
+            }
+        }
+        Commands::PayInvoice {
+            ref invoice_string,
+            amount,
+        } => {
+            let tls = read_cert_from_args(&args);
+            let grpc_host = args.grpc_host.clone();
+            let grpc_port = args.grpc_port;
+            let channel = Channel::from_shared(format!("{grpc_host}:{grpc_port}"))
+                .unwrap_or_else(|e| {
+                    println!("ERROR creating endpoint: {e:?}");
+                    exit(1)
+                })
+                .tls_config(tls)
+                .unwrap_or_else(|e| {
+                    println!("ERROR tls config: {e:?}");
+                    exit(1)
+                })
+                .connect()
+                .await
+                .unwrap_or_else(|e| {
+                    println!("ERROR connecting: {e:?}");
+                    exit(1)
+                });
+
+            let mut client = OffersClient::new(channel);
+            let macaroon = read_macaroon_from_args(&args);
+            let mut request = Request::new(PayInvoiceRequest {
+                invoice: invoice_string.to_owned(),
+                amount,
+            });
+            add_metadata(&mut request, macaroon).unwrap_or_else(|_| exit(1));
+            match client.pay_invoice(request).await {
+                Ok(_) => println!("Successfully paid for offer!"),
+                Err(err) => {
+                    println!("Error paying invoice: {err:?}");
+                    exit(1)
+                }
+            }
+        }
     }
 }
 
-fn add_metadata(request: &mut Request<PayOfferRequest>, macaroon: String) -> Result<(), ()> {
+fn add_metadata<R>(request: &mut Request<R>, macaroon: String) -> Result<(), ()> {
     let macaroon = macaroon.parse().map_err(|e| {
         println!("Error parsing provided macaroon string into tonic metadata {e:?}")
     })?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ use home::home_dir;
 use lightning::blinded_path::{BlindedPath, Direction, IntroductionNode};
 use lightning::ln::channelmanager::PaymentId;
 use lightning::ln::inbound_payment::ExpandedKey;
+use lightning::ln::msgs::DecodeError;
 use lightning::ln::peer_handler::IgnoringMessageHandler;
 use lightning::offers::invoice::Bolt12Invoice;
 use lightning::offers::invoice_error::InvoiceError;
@@ -485,6 +486,23 @@ impl OffersMessageHandler for OfferHandler {
 
     fn release_pending_messages(&self) -> Vec<PendingOnionMessage<OffersMessage>> {
         core::mem::take(&mut self.pending_messages.lock().unwrap())
+    }
+}
+
+pub struct Bolt12InvoiceString(pub String);
+
+impl TryFrom<Bolt12InvoiceString> for Bolt12Invoice {
+    type Error = DecodeError;
+
+    fn try_from(s: Bolt12InvoiceString) -> Result<Self, Self::Error> {
+        let bytes: Vec<u8> = hex::decode(s.0).unwrap();
+        Self::try_from(bytes).map_err(|_| DecodeError::InvalidValue)
+    }
+}
+
+impl From<String> for Bolt12InvoiceString {
+    fn from(s: String) -> Self {
+        Bolt12InvoiceString(s)
     }
 }
 

--- a/src/lndk_offers.rs
+++ b/src/lndk_offers.rs
@@ -102,7 +102,7 @@ impl Display for OfferError {
 
 impl Error for OfferError {}
 
-// Decodes a bech32 string into an LDK offer.
+// Decodes a bech32 offer string into an LDK offer.
 pub fn decode(offer_str: String) -> Result<Offer, Bolt12ParseError> {
     offer_str.parse::<Offer>()
 }

--- a/src/lndk_offers.rs
+++ b/src/lndk_offers.rs
@@ -653,7 +653,8 @@ impl InvoicePayer for Client {
     }
 }
 
-async fn get_node_id(
+// get_node_id finds an introduction node from the scid and direction provided by a blinded path.
+pub(crate) async fn get_node_id(
     client: Client,
     scid: u64,
     direction: Direction,

--- a/src/server.rs
+++ b/src/server.rs
@@ -59,7 +59,7 @@ impl Offers for LNDKServer {
         &self,
         request: Request<PayOfferRequest>,
     ) -> Result<Response<PayOfferResponse>, Status> {
-        log::info!("Received a request: {:?}", request);
+        log::info!("Received a request: {:?}", request.get_ref());
 
         let metadata = request.metadata();
         let macaroon = check_auth_metadata(metadata)?;


### PR DESCRIPTION
This replaces #129. Thanks to @mauricepoirrier and @mrfelton for doing a lot of the work here.

This PR puts into place a few features requested by @mrfelton/Strike. It does the following:
- Does some refactoring to make way for some new endpoints.
- Adds the `get-invoice` and `pay-invoice` endpoints in described in #124 to give users more control over making offer payments.
- Adds a `decode-invoice` endpoint that takes in a hex-encoded invoice.
- Note that `get-invoice`'s response returns the invoice in two forms: 1) in hex-encoded format 2) decoded into all its pieces as a Bolt12InvoiceContents proto.