### PR TITLE
offers: improve offer flow logs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,12 +371,12 @@ impl OffersMessageHandler for OfferHandler {
                 None
             }
             OffersMessage::Invoice(invoice) => {
+                info!("Received an invoice: {invoice:?}");
                 let secp_ctx = &Secp256k1::new();
                 // We verify that this invoice is a response to an invoice request we sent.
                 match invoice.verify(&self.expanded_key, secp_ctx) {
                     Ok(payment_id) => {
-                        info!("Received an invoice: {invoice:?}");
-
+                        info!("Successfully verified invoice for payment_id {payment_id}");
                         let mut active_payments = self.active_payments.lock().unwrap();
                         match active_payments.get_mut(&payment_id) {
                             Some(pay_info) => match pay_info.invoice {


### PR DESCRIPTION
This PR improves debugging logs by:
- Logging when we receive an unverified invoice
- Logging the introduction node in two instances: 1) The introduction node we pick in our invoice request reply path. 2) The introduction node provided in an invoice we are about to pay.