### PR TITLE
offers: handle invoice request build failures more gracefully

### DIFF
--- a/src/lndk_offers.rs
+++ b/src/lndk_offers.rs
@@ -210,11 +210,11 @@ impl OfferHandler {
                 &self.messenger_utils,
                 payment_id,
             )
-            .unwrap()
+            .map_err(OfferError::BuildUIRFailure)?
             .chain(network)
-            .unwrap()
+            .map_err(OfferError::BuildUIRFailure)?
             .amount_msats(validated_amount)
-            .unwrap()
+            .map_err(OfferError::BuildUIRFailure)?
             .build()
             .map_err(OfferError::BuildUIRFailure)?;
 


### PR DESCRIPTION
Fixes #137 and other related possible panics by removing all of the other unnecessary unwraps when building an invoice request.