### PR TITLE
system: handle SIGTERM signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,6 +2052,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,6 +2255,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rand_core = "0.6.4"
 log = "0.4.17"
 log4rs = { version = "1.2.0", features = ["file_appender"] }
 rcgen = { version = "0.13.1", features = ["pem", "x509-parser"] }
-tokio = { version = "1.25.0", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1.25.0", features = ["rt", "rt-multi-thread", "signal"] }
 tonic = { version = "0.11", features = [ "tls", "transport" ] }
 tonic_lnd = { git = "https://github.com/orbitalturtle/tonic_lnd", rev="18c5a71084886024a6b90307bfb8822288c5daea", package="fedimint-tonic-lnd", features = ["lightningrpc", "routerrpc", "versionrpc"] }
 hex = "0.4.3"


### PR DESCRIPTION
This pull request introduces signal handling to gracefully shut down the application upon receiving SIGTERM or SIGINT signals, and updates dependencies accordingly.

### Dependency Updates:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L27-R27): Added the `signal` feature to the `tokio` dependency. (`[Cargo.tomlL27-R27](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L27-R27)`)

### Signal Handling Implementation:
* `src/main.rs`: 
  * Imported `signal` and `SignalKind` from `tokio::signal::unix`. (`[src/main.rsL26-R29](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL26-R29)`)
  * Set up signal handlers for SIGTERM and SIGINT in the `main` function. (`[src/main.rsR123-R126](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR123-R126)`)
  * Added branches to the `select!` macro to handle SIGTERM and SIGINT signals, logging a shutdown message for each. (`[src/main.rsR137-R142](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR137-R142)`)

Fixes #150