### PR TITLE
main: handle termination signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,6 +2052,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,6 +2255,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rand_core = "0.6.4"
 log = "0.4.17"
 log4rs = { version = "1.2.0", features = ["file_appender"] }
 rcgen = { version = "0.13.1", features = ["pem", "x509-parser"] }
-tokio = { version = "1.25.0", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1.25.0", features = ["rt", "rt-multi-thread", "signal"] }
 tonic = { version = "0.11", features = [ "tls", "transport" ] }
 tonic_lnd = { git = "https://github.com/orbitalturtle/tonic_lnd", rev="18c5a71084886024a6b90307bfb8822288c5daea", package="fedimint-tonic-lnd", features = ["lightningrpc", "routerrpc", "versionrpc"] }
 hex = "0.4.3"


### PR DESCRIPTION
This PR fixes #150 with the following:
- Uses tokio's `signal` feature to process SIGTERM and SIGINT signals, tying them to the `triggered` LifecycleSignals we had in place already.
- Also uses the `serve_with_shutdown` tonic so the server shuts down more gracefully. Maybe it'd be worth looking to see if we can do more for a graceful shutdown later on. With this change, the server seems to work normally. But I'm realizing we don't have any quick integration tests of the server in place. This doesn't necessarily need to go in this PR... but if I have time I'll add something quick.