### PR TITLE
offers: don't include unadvertised nodes as introduction node candidates

### DIFF
--- a/src/lnd.rs
+++ b/src/lnd.rs
@@ -20,8 +20,7 @@ use std::fmt::Display;
 use std::path::PathBuf;
 use std::{fmt, fs};
 use tonic_lnd::lnrpc::{
-    GetInfoResponse, HtlcAttempt, LightningNode, ListPeersResponse, Payment, QueryRoutesResponse,
-    Route,
+    GetInfoResponse, HtlcAttempt, ListPeersResponse, NodeInfo, Payment, QueryRoutesResponse, Route,
 };
 use tonic_lnd::signrpc::{KeyDescriptor, KeyLocator};
 use tonic_lnd::tonic::Status;
@@ -404,7 +403,11 @@ pub trait MessageSigner {
 pub trait PeerConnector {
     async fn list_peers(&mut self) -> Result<ListPeersResponse, Status>;
     async fn connect_peer(&mut self, node_id: String, addr: String) -> Result<(), Status>;
-    async fn get_node_info(&mut self, pub_key: String) -> Result<Option<LightningNode>, Status>;
+    async fn get_node_info(
+        &mut self,
+        pub_key: String,
+        include_channels: bool,
+    ) -> Result<NodeInfo, Status>;
 }
 
 /// InvoicePayer provides a layer of abstraction over the LND API for paying for a BOLT 12 invoice.

--- a/src/lndk_offers.rs
+++ b/src/lndk_offers.rs
@@ -718,8 +718,12 @@ mod tests {
             .unwrap()
     }
 
-    fn get_pubkey() -> String {
-        "0313ba7ccbd754c117962b9afab6c2870eb3ef43f364a9f6c43d0fabb4553776ba".to_string()
+    fn get_pubkeys() -> Vec<String> {
+        let pubkey1 =
+            "0313ba7ccbd754c117962b9afab6c2870eb3ef43f364a9f6c43d0fabb4553776ba".to_string();
+        let pubkey2 =
+            "03b060a3b572ab060532fbe49506fe25b5957195733788aab01ab3c0f40bb52602".to_string();
+        vec![pubkey1, pubkey2]
     }
 
     fn get_invoice_request(offer: Offer, amount: u64) -> InvoiceRequest {
@@ -745,7 +749,7 @@ mod tests {
         let entropy_source = MessengerUtilities::new();
         let secp_ctx = Secp256k1::new();
         BlindedPath::new_for_message(
-            &[PublicKey::from_str(&get_pubkey()).unwrap()],
+            &[PublicKey::from_str(&get_pubkeys()[0]).unwrap()],
             &entropy_source,
             &secp_ctx,
         )
@@ -791,7 +795,7 @@ mod tests {
 
         signer_mock.expect_derive_next_key().returning(|_| {
             Ok(KeyDescriptor {
-                raw_key_bytes: PublicKey::from_str(&get_pubkey())
+                raw_key_bytes: PublicKey::from_str(&get_pubkeys()[0])
                     .unwrap()
                     .serialize()
                     .to_vec(),
@@ -859,7 +863,7 @@ mod tests {
 
         signer_mock.expect_derive_next_key().returning(|_| {
             Ok(KeyDescriptor {
-                raw_key_bytes: PublicKey::from_str(&get_pubkey())
+                raw_key_bytes: PublicKey::from_str(&get_pubkeys()[0])
                     .unwrap()
                     .serialize()
                     .to_vec(),
@@ -936,7 +940,7 @@ mod tests {
             .expect_connect_peer()
             .returning(|_, _| Ok(()));
 
-        let pubkey = PublicKey::from_str(&get_pubkey()).unwrap();
+        let pubkey = PublicKey::from_str(&get_pubkeys()[0]).unwrap();
         assert!(connect_to_peer(connector_mock, pubkey).await.is_ok());
     }
 
@@ -945,7 +949,7 @@ mod tests {
         let mut connector_mock = MockTestPeerConnector::new();
         connector_mock.expect_list_peers().returning(|| {
             let peer = tonic_lnd::lnrpc::Peer {
-                pub_key: get_pubkey(),
+                pub_key: get_pubkeys()[0].clone(),
                 ..Default::default()
             };
 
@@ -968,7 +972,7 @@ mod tests {
             Ok(Some(node))
         });
 
-        let pubkey = PublicKey::from_str(&get_pubkey()).unwrap();
+        let pubkey = PublicKey::from_str(&get_pubkeys()[0]).unwrap();
         assert!(connect_to_peer(connector_mock, pubkey).await.is_ok());
     }
 
@@ -998,7 +1002,7 @@ mod tests {
             .expect_connect_peer()
             .returning(|_, _| Err(Status::unknown("")));
 
-        let pubkey = PublicKey::from_str(&get_pubkey()).unwrap();
+        let pubkey = PublicKey::from_str(&get_pubkeys()[0]).unwrap();
         assert!(connect_to_peer(connector_mock, pubkey).await.is_err());
     }
 
@@ -1014,14 +1018,14 @@ mod tests {
             feature_entry.insert(38, feature);
 
             let peer = tonic_lnd::lnrpc::Peer {
-                pub_key: get_pubkey(),
+                pub_key: get_pubkeys()[0].clone(),
                 features: feature_entry,
                 ..Default::default()
             };
             Ok(ListPeersResponse { peers: vec![peer] })
         });
 
-        let receiver_node_id = PublicKey::from_str(&get_pubkey()).unwrap();
+        let receiver_node_id = PublicKey::from_str(&get_pubkeys()[0]).unwrap();
         let handler = OfferHandler::default();
         assert!(handler
             .create_reply_path(connector_mock, receiver_node_id)
@@ -1038,7 +1042,7 @@ mod tests {
             .expect_list_peers()
             .returning(|| Ok(ListPeersResponse { peers: vec![] }));
 
-        let receiver_node_id = PublicKey::from_str(&get_pubkey()).unwrap();
+        let receiver_node_id = PublicKey::from_str(&get_pubkeys()[0]).unwrap();
         let handler = OfferHandler::default();
         assert!(handler
             .create_reply_path(connector_mock, receiver_node_id)
@@ -1054,7 +1058,7 @@ mod tests {
             .expect_list_peers()
             .returning(|| Err(Status::unknown("unknown error")));
 
-        let receiver_node_id = PublicKey::from_str(&get_pubkey()).unwrap();
+        let receiver_node_id = PublicKey::from_str(&get_pubkeys()[0]).unwrap();
         let handler = OfferHandler::default();
         assert!(handler
             .create_reply_path(connector_mock, receiver_node_id)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -82,6 +82,7 @@ pub async fn setup_test_infrastructure(
 pub async fn connect_network(
     ldk1: &LdkNode,
     ldk2: &LdkNode,
+    announce_channel: bool,
     lnd: &mut LndNode,
     bitcoind: &BitcoindNode,
 ) -> (PublicKey, PublicKey, PublicKey) {
@@ -136,7 +137,7 @@ pub async fn connect_network(
         SocketAddr::from_str(&lnd_network_addr).unwrap(),
         200000,
         10000000,
-        true,
+        announce_channel,
     )
     .await
     .unwrap();


### PR DESCRIPTION
When requesting an invoice from an offer, we need to create a reply path for the offer node to reply to. When creating this path we currently don't check whether the introduction node we selected is advertised (with public channels) or not: https://github.com/lndk-org/lndk/blob/259de8b8ef0916393a47d96076db518cf94651f9/src/lndk_offers.rs#L254 

This PR makes sure we pick an advertised node, which the offer node will actually be able to reach, potentially improving payment reliability.