### PR TITLE
offers: add back extra cltv expiry delta

### DIFF
--- a/src/lndk_offers.rs
+++ b/src/lndk_offers.rs
@@ -603,7 +603,7 @@ impl InvoicePayer for Client {
 
         let blinded_payment_paths = tonic_lnd::lnrpc::BlindedPaymentPath {
             blinded_path,
-            total_cltv_delta: u32::from(cltv_expiry_delta),
+            total_cltv_delta: u32::from(cltv_expiry_delta) + 120,
             base_fee_msat: u64::from(fee_base_msat),
             proportional_fee_msat: u64::from(fee_ppm),
             ..Default::default()


### PR DESCRIPTION
We had removed this expiry delta because payments to more recent versions of LDK and CLN were working without it. But without it, some payments to Eclair and other versions fail.