### PR TITLE
chore: use any linux version for protoc on release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ protobuf = { version = "27.3_1" }
 
 # Release dependencies for Linux
 [workspace.metadata.dist.dependencies.apt]
-protobuf-compiler = { version = "3.27.3-1" }
+protobuf-compiler = '*'
 
 # Release dependencies for Windows
 [workspace.metadata.dist.dependencies.chocolatey]


### PR DESCRIPTION
Give us what we can even use and we'll pin the protobuf-compiler dependency after the release build.