### PR TITLE
chore: disable windows release support for now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,9 +57,9 @@ cargo-dist-version = "0.21.1"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["shell", "powershell"]
+installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
 # Whether to install an updater program
@@ -76,10 +76,6 @@ protobuf = { version = "27.3_1" }
 # Release dependencies for Linux
 [workspace.metadata.dist.dependencies.apt]
 protobuf-compiler = { version = "3.21.12-8.2build1" }
-
-# Release dependencies for Windows
-[workspace.metadata.dist.dependencies.chocolatey]
-protoc = { version = "27.3.0" }
 
 # Use more recent version of ubuntu
 [workspace.metadata.dist.github-custom-runners]


### PR DESCRIPTION
LNDK builds are (have been) broken on windows. Disabling release for windows for now.