### PR TITLE
tests: basic cli/server integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,24 @@
 
 GO_BUILD := go build
 CARGO_TEST := cargo test
+CARGO_BUILD := cargo build
 LND_PKG := github.com/lightningnetwork/lnd
 
 TMP_DIR := "/tmp"
+BIN_DIR := $(TMP_DIR)/lndk-tests/bin
+
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
         TMP_DIR=${TMPDIR}
 endif
 
 itest:
-	@$(call print, "Building lnd for itests.")
+	@echo Building lnd for itests.
 	git submodule update --init --recursive
-	cd lnd/cmd/lnd; $(GO_BUILD) -tags="peersrpc signrpc walletrpc dev" -o $(TMP_DIR)/lndk-tests/bin/lnd-itest$(EXEC_SUFFIX)
-	$(CARGO_TEST) --test '*' -- --test-threads=1 --nocapture
+	cd lnd/cmd/lnd; $(GO_BUILD) -tags="peersrpc signrpc walletrpc dev" -o $(BIN_DIR)/lnd-itest$(EXEC_SUFFIX)
 
+	@echo Building lndk-cli for itests.
+	# This outputs the lndk-cli binary into $(BINDIR)/debug/
+	$(CARGO_BUILD) --bin=lndk-cli --target-dir=$(BIN_DIR)
+
+	$(CARGO_TEST) --test '*' -- --test-threads=1 --nocapture

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,9 +3,9 @@ use lightning::offers::invoice::Bolt12Invoice;
 use lndk::lndk_offers::decode;
 use lndk::lndkrpc::offers_client::OffersClient;
 use lndk::lndkrpc::{GetInvoiceRequest, PayInvoiceRequest, PayOfferRequest};
+use lndk::server::{DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT};
 use lndk::{
-    Bolt12InvoiceString, DEFAULT_DATA_DIR, DEFAULT_RESPONSE_INVOICE_TIMEOUT, DEFAULT_SERVER_HOST,
-    DEFAULT_SERVER_PORT, TLS_CERT_FILENAME,
+    Bolt12InvoiceString, DEFAULT_DATA_DIR, DEFAULT_RESPONSE_INVOICE_TIMEOUT, TLS_CERT_FILENAME,
 };
 use std::fs::File;
 use std::io::BufReader;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,8 +213,8 @@ impl LndkOnionMessenger {
         }
 
         // Create an onion messenger that depends on LND's signer client and consume related events.
-        let mut node_client = client.signer().clone();
-        let node_signer = LndNodeSigner::new(pubkey, &mut node_client);
+        let node_client = client.clone().signer_read_only();
+        let node_signer = LndNodeSigner::new(pubkey, node_client);
         let messenger_utils = MessengerUtilities::new();
         let network_graph = &NetworkGraph::new(network, &messenger_utils);
         let message_router = &DefaultMessageRouter::new(network_graph, &messenger_utils);
@@ -229,10 +229,10 @@ impl LndkOnionMessenger {
             IgnoringMessageHandler {},
         );
 
-        let mut peers_client = client.lightning().clone();
+        let peers_client = client.lightning().clone();
         self.run_onion_messenger(
             peer_support,
-            &mut peers_client,
+            &peers_client,
             onion_messenger,
             network,
             args.signals,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,6 @@ pub fn init_logger(config: LogConfig) {
     });
 }
 
-pub const DEFAULT_SERVER_HOST: &str = "127.0.0.1";
-pub const DEFAULT_SERVER_PORT: u16 = 7000;
 pub const LDK_LOGGER_NAME: &str = "ldk";
 pub const DEFAULT_DATA_DIR: &str = ".lndk";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,15 +11,11 @@ mod internal {
 
 use home::home_dir;
 use internal::*;
-use lndk::lnd::{get_lnd_client, validate_lnd_creds, LndCfg};
-use lndk::server::{
-    generate_tls_creds, read_tls, LNDKServer, DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT,
-};
+use lndk::lnd::{validate_lnd_creds, LndCfg};
+use lndk::server::setup_server;
 use lndk::{
-    lndkrpc, setup_logger, Cfg, LifecycleSignals, LndkOnionMessenger, OfferHandler,
-    DEFAULT_DATA_DIR,
+    setup_logger, Cfg, LifecycleSignals, LndkOnionMessenger, OfferHandler, DEFAULT_DATA_DIR,
 };
-use lndkrpc::offers_server::OffersServer;
 use log::{error, info};
 use std::fs::create_dir_all;
 use std::path::PathBuf;
@@ -27,8 +23,6 @@ use std::process::exit;
 use std::sync::Arc;
 use tokio::select;
 use tokio::signal::unix::SignalKind;
-use tonic::transport::{Server, ServerTlsConfig};
-use tonic_lnd::lnrpc::GetInfoRequest;
 
 #[macro_use]
 extern crate configure_me;
@@ -95,51 +89,17 @@ async fn main() -> Result<(), ()> {
     let handler = Arc::new(OfferHandler::new(config.response_invoice_timeout));
     let messenger = LndkOnionMessenger::new();
 
-    let mut client = get_lnd_client(args.lnd.clone()).expect("failed to connect to lnd");
-    let info = client
-        .lightning()
-        .get_info(GetInfoRequest {})
-        .await
-        .expect("failed to get info")
-        .into_inner();
-
-    let grpc_host = match config.grpc_host {
-        Some(host) => host,
-        None => DEFAULT_SERVER_HOST.to_string(),
-    };
-    let grpc_port = match config.grpc_port {
-        Some(port) => port,
-        None => DEFAULT_SERVER_PORT,
-    };
-    let addr = format!("{grpc_host}:{grpc_port}").parse().map_err(|e| {
-        error!("Error parsing API address: {e}");
-    })?;
-    let lnd_tls_str = creds.get_certificate_string()?;
-
-    // The user passed in a TLS cert to help us establish a secure connection to LND. But now we
-    // need to generate a TLS credentials for connecting securely to the LNDK server.
-    generate_tls_creds(data_dir.clone(), config.tls_ip).map_err(|e| {
-        error!("Error generating tls credentials: {e}");
-    })?;
-    let identity = read_tls(data_dir).map_err(|e| {
-        error!("Error reading tls credentials: {e}");
-    })?;
-
-    let server = LNDKServer::new(
+    let server_fut = setup_server(
+        args.lnd.clone(),
+        config.grpc_host,
+        config.grpc_port,
+        data_dir,
+        config.tls_ip,
         Arc::clone(&handler),
-        &info.identity_pubkey,
-        lnd_tls_str,
         address,
     )
-    .await;
-
-    let server_fut = Server::builder()
-        .tls_config(ServerTlsConfig::new().identity(identity))
-        .expect("couldn't configure tls")
-        .add_service(OffersServer::new(server))
-        .serve_with_shutdown(addr, listener);
-
-    info!("Starting lndk's grpc server at address {grpc_host}:{grpc_port}");
+    .await
+    .map_err(|e| error!("Error setting up server: {:?}", e))?;
 
     select! {
        _ = messenger.run(args, Arc::clone(&handler)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,12 @@ mod internal {
 use home::home_dir;
 use internal::*;
 use lndk::lnd::{get_lnd_client, validate_lnd_creds, LndCfg};
-use lndk::server::{generate_tls_creds, read_tls, LNDKServer};
+use lndk::server::{
+    generate_tls_creds, read_tls, LNDKServer, DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT,
+};
 use lndk::{
     lndkrpc, setup_logger, Cfg, LifecycleSignals, LndkOnionMessenger, OfferHandler,
-    DEFAULT_DATA_DIR, DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT,
+    DEFAULT_DATA_DIR,
 };
 use lndkrpc::offers_server::OffersServer;
 use log::{error, info};

--- a/src/onion_messenger.rs
+++ b/src/onion_messenger.rs
@@ -163,7 +163,7 @@ impl LndkOnionMessenger {
     >(
         &self,
         current_peers: HashMap<PublicKey, bool>,
-        ln_client: &mut tonic_lnd::LightningClient,
+        ln_client: &tonic_lnd::LightningClient,
         onion_messenger: OnionMessenger<ES, NS, L, NL, MR, OMH, CMH>,
         network: Network,
         signals: LifecycleSignals,
@@ -266,10 +266,8 @@ impl LndkOnionMessenger {
             }
         });
 
-        // Consume events is our main controlling loop, so we run it inline here. We use a RefCell
-        // in onion_messenger to allow interior mutability (see LndNodeSigner) so this
-        // function can't safely be passed off to another thread. This function is expected
-        // to finish if any producing thread exits (because we're no longer receiving the
+        // Consume events is our main controlling loop, so we run it inline here. This function is
+        // expected to finish if any producing thread exits (because we're no longer receiving the
         // events we need).
         let rate_limiter = &mut TokenLimiter::new(
             current_peers.keys().copied(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -12,23 +12,25 @@ use lightning::offers::invoice::{BlindedPayInfo, Bolt12Invoice};
 use lightning::offers::offer::Offer;
 use lightning::sign::EntropySource;
 use lightning::util::ser::Writeable;
-use lndkrpc::offers_server::Offers;
+use lndkrpc::offers_server::{Offers, OffersServer};
 use lndkrpc::{
     Bolt12InvoiceContents, DecodeInvoiceRequest, FeatureBit, GetInvoiceRequest, GetInvoiceResponse,
     PayInvoiceRequest, PayInvoiceResponse, PayOfferRequest, PayOfferResponse, PaymentHash,
     PaymentPaths,
 };
+use log::{error, info};
 use rcgen::{generate_simple_self_signed, CertifiedKey, Error as RcgenError};
 use std::error::Error;
 use std::fmt::Display;
 use std::fs::{metadata, set_permissions, File};
+use std::future::Future;
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use tonic::metadata::MetadataMap;
-use tonic::transport::Identity;
+use tonic::transport::{Identity, Server, ServerTlsConfig};
 use tonic::{Request, Response, Status};
 use tonic_lnd::lnrpc::GetInfoRequest;
 
@@ -312,6 +314,64 @@ fn check_auth_metadata(metadata: &MetadataMap) -> Result<String, Status> {
     };
 
     Ok(macaroon)
+}
+
+pub async fn setup_server(
+    lnd_cfg: LndCfg,
+    grpc_host: Option<String>,
+    grpc_port: Option<u16>,
+    data_dir: PathBuf,
+    tls_ip: Option<String>,
+    handler: Arc<OfferHandler>,
+    lnd_address: String,
+) -> Result<impl Future<Output = Result<(), tonic::transport::Error>>, ()> {
+    let mut client = get_lnd_client(lnd_cfg.clone()).expect("failed to connect to lnd");
+    let info = client
+        .lightning()
+        .get_info(GetInfoRequest {})
+        .await
+        .expect("failed to get info")
+        .into_inner();
+
+    let grpc_host = match grpc_host {
+        Some(host) => host,
+        None => DEFAULT_SERVER_HOST.to_string(),
+    };
+    let grpc_port = match grpc_port {
+        Some(port) => port,
+        None => DEFAULT_SERVER_PORT,
+    };
+    let addr = format!("{grpc_host}:{grpc_port}").parse().map_err(|e| {
+        error!("Error parsing API address: {e}");
+    })?;
+    let lnd_tls_str = lnd_cfg.creds.get_certificate_string()?;
+
+    // The user passed in a TLS cert to help us establish a secure connection to LND. But now we
+    // need to generate a TLS credentials for connecting securely to the LNDK server.
+    generate_tls_creds(data_dir.clone(), tls_ip).map_err(|e| {
+        error!("Error generating tls credentials: {e}");
+    })?;
+    let identity = read_tls(data_dir).map_err(|e| {
+        error!("Error reading tls credentials: {e}");
+    })?;
+
+    let server = LNDKServer::new(
+        Arc::clone(&handler),
+        &info.identity_pubkey,
+        lnd_tls_str,
+        lnd_address,
+    )
+    .await;
+
+    let server_fut = Server::builder()
+        .tls_config(ServerTlsConfig::new().identity(identity))
+        .expect("couldn't configure tls")
+        .add_service(OffersServer::new(server))
+        .serve(addr);
+
+    info!("Starting lndk's grpc server at address {grpc_host}:{grpc_port}");
+
+    Ok(server_fut)
 }
 
 /// An error that occurs when generating TLS credentials.

--- a/src/server.rs
+++ b/src/server.rs
@@ -42,7 +42,7 @@ pub struct LNDKServer {
     node_id: PublicKey,
     // The LND tls cert we need to establish a connection with LND.
     lnd_cert: String,
-    address: String,
+    lnd_address: String,
 }
 
 impl LNDKServer {
@@ -50,13 +50,13 @@ impl LNDKServer {
         offer_handler: Arc<OfferHandler>,
         node_id: &str,
         lnd_cert: String,
-        address: String,
+        lnd_address: String,
     ) -> Self {
         Self {
             offer_handler,
             node_id: PublicKey::from_str(node_id).unwrap(),
             lnd_cert,
-            address,
+            lnd_address,
         }
     }
 }
@@ -75,7 +75,7 @@ impl Offers for LNDKServer {
             cert: self.lnd_cert.clone(),
             macaroon,
         };
-        let lnd_cfg = LndCfg::new(self.address.clone(), creds);
+        let lnd_cfg = LndCfg::new(self.lnd_address.clone(), creds);
         let mut client = get_lnd_client(lnd_cfg)
             .map_err(|e| Status::unavailable(format!("Couldn't connect to lnd: {e}")))?;
 
@@ -171,7 +171,7 @@ impl Offers for LNDKServer {
             cert: self.lnd_cert.clone(),
             macaroon,
         };
-        let lnd_cfg = LndCfg::new(self.address.clone(), creds);
+        let lnd_cfg = LndCfg::new(self.lnd_address.clone(), creds);
         let mut client = get_lnd_client(lnd_cfg)
             .map_err(|e| Status::unavailable(format!("Couldn't connect to lnd: {e}")))?;
 
@@ -258,7 +258,7 @@ impl Offers for LNDKServer {
             cert: self.lnd_cert.clone(),
             macaroon,
         };
-        let lnd_cfg = LndCfg::new(self.address.clone(), creds);
+        let lnd_cfg = LndCfg::new(self.lnd_address.clone(), creds);
         let client = get_lnd_client(lnd_cfg)
             .map_err(|e| Status::unavailable(format!("Couldn't connect to lnd: {e}")))?;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -31,6 +31,10 @@ use tonic::metadata::MetadataMap;
 use tonic::transport::Identity;
 use tonic::{Request, Response, Status};
 use tonic_lnd::lnrpc::GetInfoRequest;
+
+pub const DEFAULT_SERVER_HOST: &str = "127.0.0.1";
+pub const DEFAULT_SERVER_PORT: u16 = 7000;
+
 pub struct LNDKServer {
     offer_handler: Arc<OfferHandler>,
     node_id: PublicKey,


### PR DESCRIPTION
This PR puts a basic test of the server in place, testing that the cli + server can properly make a payment.

To do so required a little refactoring:
- IIUC initially a RefCell was added to the LndNodeSigner because the original version of tonic_lnd returns a mutable reference to the signer. However I don't think this reference [needs to be mutable](https://github.com/orbitalturtle/tonic_lnd/pull/4). For this PR, this was needed so we could spin up the onion messenger and server in a separate thread in the integration tests. But it's a change that could help with future efficiency as well now the onion messenger can be used in a multi-threaded way.
- Split off the server formation logic from main.rs into a separate function so that we can call it in the integration tests as well.