### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Or in a more concrete example:
 * In the lndk directory, create file named `lndk.conf`.
 * Add the following lines to the file:
   * `address="<ADDRESS"`
-  * `cert-path="<TLSPATH>"`
-  * `macaroon-path="<MACAROONPATH>"`
+  * `cert_path="<TLSPATH>"`
+  * `macaroon_path="<MACAROONPATH>"`
 * Run `cargo run --bin=lndk -- --conf lndk.conf`
 
 - Use any of the commands with the --help option for more information about each argument.


### PR DESCRIPTION
Example variable names for `lndk.conf` were incorrect.  They need to be snake_case rather than kebab-case.

Specifically: 
`cert-path` --> `cert_path`
`macaroon-path` --> `macaroon_path`