### PR TITLE
chore: update variable names & provide clarity on features in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,17 @@
 LNDK is a standalone daemon that connects to [LND](https://github.com/lightningnetwork/lnd) (via its grpc API) that aims to implement [bolt 12](https://github.com/lightning/bolts/pull/798) functionality _externally_ to LND. LNDK leverages the [lightning development kit](https://github.com/lightningdevkit/rust-lightning) to provide functionality, acting as a thin "shim" between LND's APIs and LDK's lightning library.
 
 Project Milestones:
+
 - [x] [v0.1.0](https://github.com/lndk-org/lndk/milestone/1): Onion message forwarding for LND.
 - [x] [v0.2.0](https://github.com/lndk-org/lndk/milestone/2): Payment to offers with blinded paths.
 
-*Please note that this project is still experimental.*
+_Please note that this project is still experimental._
 
 ## Resources
-* [Contributor guidelines](https://github.com/lndk-org/lndk/blob/master/CONTRIBUTING.md)
-* [Code of Conduct](https://github.com/lndk-org/lndk/blob/master/code_of_conduct.md)
-* [Architecture](https://github.com/lndk-org/lndk/blob/master/ARCH.md)
+
+- [Contributor guidelines](https://github.com/lndk-org/lndk/blob/master/CONTRIBUTING.md)
+- [Code of Conduct](https://github.com/lndk-org/lndk/blob/master/code_of_conduct.md)
+- [Architecture](https://github.com/lndk-org/lndk/blob/master/ARCH.md)
 
 When you encounter a problem with `LNDK`, Feel free to file issues or start [a discussion](https://github.com/lndk-org/lndk/discussions). If your question doesn't fit in either place, find us in the [BOLT 12 Discord](https://discord.gg/Pk7mT3FQFn) in the lndk channel.
 
@@ -33,11 +35,11 @@ Once you're ready to run `LND`, the binary must be run with `--protocol.custom-m
 
 There are two ways you can do this:
 
-1) Pass these options directly to `LND` when running it:
+1. Pass these options directly to `LND` when running it:
 
 `lnd --protocol.custom-message=513 --protocol.custom-nodeann=39 --protocol.custom-init=39`
 
-2) Adding these to the config file `lnd.conf`:
+2. Adding these to the config file `lnd.conf`:
 
 ```
 [protocol]
@@ -46,11 +48,12 @@ protocol.custom-nodeann=39
 protocol.custom-init=39
 ```
 
-#### Two options for LNDK
+#### Two features of LNDK
 
-Now that we have LND set up properly, there are two key things you can do with LNDK: 
-1) Forward onion messages. By increasing the number of Lightning nodes out there that can forward onion messages, this increases the anonymity set and helps to bootstrap BOLT 12 for more private payments.
-2) Pay BOLT 12 offers, a more private standard for receiving payments over Lightning, which also allows for static invoices.
+Now that we have LND set up properly, there are two key things you can do with LNDK:
+
+1. Forward onion messages. By increasing the number of Lightning nodes out there that can forward onion messages, this increases the anonymity set and helps to bootstrap BOLT 12 for more private payments.
+2. Pay BOLT 12 offers, a more private standard for receiving payments over Lightning, which also allows for static invoices.
 
 To accomplish #1, follow the instructions below to get the LNDK binary up and running. Once you have LNDK up and running, you can accomplish #2
 [here](https://github.com/lndk-org/lndk/blob/master/docs/cli_commands.md) with either `lndk-cli` or setting up your own gRPC client.
@@ -63,15 +66,17 @@ Now we need to set up LNDK. To start:
 git clone https://github.com/lndk-org/lndk
 cd lndk
 ```
-In order for `LNDK` successfully connect to `LND`, we need to pass in the grpc address and authentication credentials. 
+
+In order for `LNDK` successfully connect to `LND`, we need to pass in the grpc address and authentication credentials.
 
 As you can see in `LNDK`'s [config specifications file](https://github.com/lndk-org/lndk/blob/master/config_spec.toml), there's two ways to pass in the credentials:
-1) By path with the `cert-path` and `macaroon-path` arguments. 
-2) Directly, with the `cert-pem` and `macaroon-hex` arguments.
+
+1. By path with the `cert-path` and `macaroon-path` arguments.
+2. Directly, with the `cert-pem` and `macaroon-hex` arguments.
 
 With that in mind, there are two ways to pass in the arguments to `LNDK`:
 
-1) These values can be passed in via the command line when running the `LNDK` program, like this:
+1. These values can be passed in via the command line when running the `LNDK` program, like this:
 
 `cargo run --bin=lndk -- --address=<ADDRESS> --cert-path=<TLSPATH> --macaroon-path=<MACAROONPATH>`
 
@@ -81,16 +86,16 @@ Or in a more concrete example:
 
 **Remember** that the grpc address must start with https:// for the program to work.
 
-2) Alternatively, you can use a configuration file to add the required arguments.
+2. Alternatively, you can use a configuration file to add the required arguments.
 
-* In the lndk directory, create file named `lndk.conf`.
-* Add the following lines to the file:
-  * `address="<ADDRESS"`
-  * `cert-path="<TLSPATH>"`
-  * `macaroon-path="<MACAROONPATH>"`
-* Run `cargo run --bin=lndk -- --conf lndk.conf`
+- In the lndk directory, create file named `lndk.conf`.
+- Add the following lines to the file:
+  - `address="<ADDRESS"`
+  - `cert_path="<TLSPATH>"`
+  - `macaroon_path="<MACAROONPATH>"`
+- Run `cargo run --bin=lndk -- --conf lndk.conf`
 
-- Use any of the commands with the --help option for more information about each argument.
+* Use any of the commands with the --help option for more information about each argument.
 
 #### Custom macaroon
 


### PR DESCRIPTION
In the README, example variable names for `lndk.conf` were incorrect. They need to be snake_case rather than kebab-case.

Specifically:
`cert-path` --> `cert_path`
`macaroon-path` --> `macaroon_path`

This commit updates the README with the proper variable names.

Additionally, this commit changes the wording for clarity by specifying LNDK "features" rather than "options".