### PR TITLE
Added data_dir configuration options.

### DIFF
--- a/config_spec.toml
+++ b/config_spec.toml
@@ -45,7 +45,7 @@ doc = "The path to the lndk data directory. By default this is stored in ~/.lndk
 [[param]]
 name = "log_file"
 type = "String"
-doc = "The path to the lndk log file. By default this is stored in ~/.lndk"
+doc = "The path to the lndk log file. If not specified, defaults to `<data_dir>/lndk.log`."
 
 [[param]]
 name = "log_level"

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -38,6 +38,11 @@ optional = true
 doc = "The hex encoded macaroon to pass directly into LNDK"
 
 [[param]]
+name = "data_dir"
+type = "String"
+doc = "The path to the lndk data directory. By default this is stored in ~/.lndk"
+
+[[param]]
 name = "log_dir"
 type = "String"
 doc = "The path to the lndk log file. By default this is stored in ~/.lndk"

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -43,7 +43,7 @@ type = "String"
 doc = "The path to the lndk data directory. By default this is stored in ~/.lndk"
 
 [[param]]
-name = "log_dir"
+name = "log_file"
 type = "String"
 doc = "The path to the lndk log file. By default this is stored in ~/.lndk"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use lndk::lnd::{get_lnd_client, validate_lnd_creds, LndCfg};
 use lndk::server::{generate_tls_creds, read_tls, LNDKServer};
 use lndk::{
     lndkrpc, setup_logger, Cfg, LifecycleSignals, LndkOnionMessenger, OfferHandler,
-    DEFAULT_DATA_DIR, DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT,
+    DEFAULT_DATA_DIR, DEFAULT_LOG_FILE, DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT,
 };
 use lndkrpc::offers_server::OffersServer;
 use log::{error, info};
@@ -37,9 +37,14 @@ async fn main() -> Result<(), ()> {
         .unwrap_or_exit()
         .0;
 
-    let data_dir = create_data_dir(config.data_dir)
+    let data_dir = create_data_dir(&config.data_dir)
         .map_err(|e| println!("Error creating LNDK's data dir {e:?}"))?;
-    setup_logger(config.log_level, config.log_file)?;
+
+    let log_file = config.log_file.map(PathBuf::from).or(config
+        .data_dir
+        .map(|data_dir| PathBuf::from(data_dir).join(DEFAULT_LOG_FILE)));
+
+    setup_logger(config.log_level, log_file)?;
 
     let creds = validate_lnd_creds(
         config.cert_path,
@@ -157,7 +162,7 @@ async fn main() -> Result<(), ()> {
 }
 
 // Creates lndk's data directory at the specified directory, or ~/.lndk if not specified.
-fn create_data_dir(data_dir: Option<String>) -> Result<PathBuf, std::io::Error> {
+fn create_data_dir(data_dir: &Option<String>) -> Result<PathBuf, std::io::Error> {
     let path = match data_dir {
         Some(dir) => PathBuf::from(&dir),
         None => home_dir().unwrap().join(DEFAULT_DATA_DIR),

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,8 @@ async fn main() -> Result<(), ()> {
         .unwrap_or_exit()
         .0;
 
-    let data_dir =
-        create_data_dir().map_err(|e| println!("Error creating LNDK's data dir {e:?}"))?;
+    let data_dir = create_data_dir(config.data_dir)
+        .map_err(|e| println!("Error creating LNDK's data dir {e:?}"))?;
     setup_logger(config.log_level, config.log_dir)?;
 
     let creds = validate_lnd_creds(
@@ -156,9 +156,13 @@ async fn main() -> Result<(), ()> {
     Ok(())
 }
 
-// Creates lndk's data directory at ~/.lndk.
-fn create_data_dir() -> Result<PathBuf, std::io::Error> {
-    let path = home_dir().unwrap().join(DEFAULT_DATA_DIR);
+// Creates lndk's data directory at the specified directory, or ~/.lndk if not specified.
+fn create_data_dir(data_dir: Option<String>) -> Result<PathBuf, std::io::Error> {
+    let path = match data_dir {
+        Some(dir) => PathBuf::from(&dir),
+        None => home_dir().unwrap().join(DEFAULT_DATA_DIR),
+    };
+
     create_dir_all(&path)?;
 
     Ok(path)

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), ()> {
 
     let data_dir = create_data_dir(config.data_dir)
         .map_err(|e| println!("Error creating LNDK's data dir {e:?}"))?;
-    setup_logger(config.log_level, config.log_dir)?;
+    setup_logger(config.log_level, config.log_file)?;
 
     let creds = validate_lnd_creds(
         config.cert_path,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -193,13 +193,7 @@ pub async fn setup_lndk(
     let handler = Arc::new(lndk::OfferHandler::default());
     let messenger = lndk::LndkOnionMessenger::new();
 
-    let log_file = Some(
-        lndk_dir
-            .join(format!("lndk-logs.txt"))
-            .to_str()
-            .unwrap()
-            .to_string(),
-    );
+    let log_file = Some(lndk_dir.join(format!("lndk-logs.txt")));
     setup_logger(None, log_file).unwrap();
 
     return (lndk_cfg, handler, messenger, shutdown);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -193,14 +193,14 @@ pub async fn setup_lndk(
     let handler = Arc::new(lndk::OfferHandler::default());
     let messenger = lndk::LndkOnionMessenger::new();
 
-    let log_dir = Some(
+    let log_file = Some(
         lndk_dir
             .join(format!("lndk-logs.txt"))
             .to_str()
             .unwrap()
             .to_string(),
     );
-    setup_logger(None, log_dir).unwrap();
+    setup_logger(None, log_file).unwrap();
 
     return (lndk_cfg, handler, messenger, shutdown);
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -209,14 +209,14 @@ async fn test_lndk_send_invoice_request() {
         }
     }
 
-    let log_dir = Some(
+    let log_file = Some(
         lndk_dir
             .join(format!("lndk-logs.txt"))
             .to_str()
             .unwrap()
             .to_string(),
     );
-    setup_logger(None, log_dir).unwrap();
+    setup_logger(None, log_file).unwrap();
 
     // Make sure lndk successfully sends the invoice_request.
     let handler = Arc::new(lndk::OfferHandler::default());
@@ -266,14 +266,14 @@ async fn test_lndk_send_invoice_request() {
         rate_limit_period_secs: 1,
     };
 
-    let log_dir = Some(
+    let log_file = Some(
         lndk_dir
             .join(format!("lndk-logs.txt"))
             .to_str()
             .unwrap()
             .to_string(),
     );
-    setup_logger(None, log_dir).unwrap();
+    setup_logger(None, log_file).unwrap();
 
     let handler = Arc::new(lndk::OfferHandler::default());
     let messenger = lndk::LndkOnionMessenger::new();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -209,13 +209,7 @@ async fn test_lndk_send_invoice_request() {
         }
     }
 
-    let log_file = Some(
-        lndk_dir
-            .join(format!("lndk-logs.txt"))
-            .to_str()
-            .unwrap()
-            .to_string(),
-    );
+    let log_file = Some(lndk_dir.join(format!("lndk-logs.txt")));
     setup_logger(None, log_file).unwrap();
 
     // Make sure lndk successfully sends the invoice_request.
@@ -266,13 +260,7 @@ async fn test_lndk_send_invoice_request() {
         rate_limit_period_secs: 1,
     };
 
-    let log_file = Some(
-        lndk_dir
-            .join(format!("lndk-logs.txt"))
-            .to_str()
-            .unwrap()
-            .to_string(),
-    );
+    let log_file = Some(lndk_dir.join(format!("lndk-logs.txt")));
     setup_logger(None, log_file).unwrap();
 
     let handler = Arc::new(lndk::OfferHandler::default());


### PR DESCRIPTION
In certain deployment scenarios, we may not want (or be able) to write to the default ~/.lndk data directory. For example, the home directory may be mounted as read-only, or mounted using ephemeral storage.

This change adds a new `data_dir` configuration option to specify where LNDK should store data. If this option isn't specified, then falls back to the default ~/.lndk.