### PR TITLE
Server: Config defaults to root and Datadir

### DIFF
--- a/config_spec.toml
+++ b/config_spec.toml
@@ -40,7 +40,7 @@ doc = "The hex encoded macaroon to pass directly into LNDK"
 [[param]]
 name = "data_dir"
 type = "String"
-doc = "The path to the lndk data directory. By default this is stored in ~/.lndk"
+doc = "The path to the lndk data directory. By default this is stored in ~/.lndk/data"
 
 [[param]]
 name = "log_file"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,8 +62,10 @@ pub fn init_logger(config: LogConfig) {
 pub const DEFAULT_SERVER_HOST: &str = "127.0.0.1";
 pub const DEFAULT_SERVER_PORT: u16 = 7000;
 pub const LDK_LOGGER_NAME: &str = "ldk";
-pub const DEFAULT_DATA_DIR: &str = ".lndk";
+pub const DEFAULT_DATA_DIR: &str = "data";
+pub const DEFAULT_LNDK_DIR: &str = ".lndk";
 pub const DEFAULT_LOG_FILE: &str = "lndk.log";
+pub const DEFAULT_CONFIG_FILE_NAME: &str = "lndk.conf";
 
 pub const TLS_CERT_FILENAME: &str = "tls-cert.pem";
 pub const TLS_KEY_FILENAME: &str = "tls-key.pem";


### PR DESCRIPTION
Should close #183

## In this PR
Similar to bitcoin `~/.bitcoin/bitcoin.conf` and `~/.lnd/lnd.conf`, we add ~./lndk as default path to store conf file. 
Added some prevalence root project conf.file wouldn't be overriden by lndk dir conf file.

We move the datadir to defaults to `~/.lndk/data`. If `~/.lndk` does not exists, it tries to create it.

We don't store it inside networks _yet_ as LNDK does not have a concept of network in server, but it does using cli

## How can i test it?

Add some files with different configurations:
- `lndk.conf` in root project
- `~/.lndk/lndk.conf`

Test which configurations are used. Easy way to do it is to point to different lnd servers and point `address` in each file to each of them.

## Why this?
_Standardness_ and ease when deploying