### PR TITLE
Update dist & installation docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.27.1/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.28.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ To accomplish #1, follow the instructions below to get the LNDK binary up and ru
 
 #### Running LNDK
 
+On Ubuntu 22.04 or later, install the following prerequisites:
+
+```
+apt update && apt install -y protobuf-compiler build-essential
+```
+
+On macOS, you can install protoc using homebrew:
+
+```
+brew install protobuf
+```
+
+Note that you'll need `protoc` `v0.12.0` or later which supports the `--experimental_allow_proto3_optional` flag.
+
+If you don't have a Rust toolchain (`cargo` and friends) installed, you can do that via your package manager, or [rustup](https://www.rust-lang.org/tools/install)
+([non-curl-based methods available](https://forge.rust-lang.org/infra/other-installation-methods.html)).
+
 Now we need to set up LNDK. To start:
 
 ```

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,13 +4,13 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.27.1"
+cargo-dist-version = "0.28.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
 installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"]
+targets = ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
 # Whether to install an updater program

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -49,10 +49,10 @@ If your macaroon is in the default location, paying an offer looks like:
 
 If your macaroon is not in the default location, an example command looks like:
 
-`lndk-cli -- --network=mainnet --macaroon-path=/credentials/custom.macaroon pay-offer <OFFER_STRING> <AMOUNT_MSATS>`
+`lndk-cli --network=mainnet --macaroon-path=/credentials/custom.macaroon pay-offer <OFFER_STRING> <AMOUNT_MSATS>`
 
 Or you can pass in the credentials directly with a macaroon string like:
-`lndk-cli -- --network=mainnet --macaroon-hex=<MACAROON_HEX_STR> pay-offer <OFFER_STRING> <AMOUNT_MSATS>`
+`lndk-cli --network=mainnet --macaroon-hex=<MACAROON_HEX_STR> pay-offer <OFFER_STRING> <AMOUNT_MSATS>`
 
 ## gRPC client example
 


### PR DESCRIPTION
This updates `dist` to 0.28.0.

And also fixes #189, and partially addresses #182 (does not advise on glibc linking minimums etc.)