### PR TITLE
chore: add simple nix flake

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
   ubuntu-integration-test:
     name: run ubuntu unit and integration tests
     runs-on: ubuntu-latest
+    env:
+      TMPDIR: /tmp
     steps:
       - uses: actions/checkout@v4
         with:
@@ -67,8 +69,6 @@ jobs:
   check-flake:
     name: Check Nix Flake
     runs-on: ubuntu-latest
-    env:
-      FNAME: bitcoin-22.1-x86_64-linux-gnu.tar.gz
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -82,7 +82,5 @@ jobs:
         uses: cachix/install-nix-action@V27
         with:
           nix_path: nixpkgs=channel:nixos-24.05
-      - run: echo "BITCOIND_TARBALL_FILE=./${FNAME}" >> $GITHUB_ENV
-      - run: wget -q https://bitcoincore.org/bin/bitcoin-core-22.1/${FNAME}
-      - name: Check flake (excluding integration tests)
-        run: BITCOIND_TARBALL_FILE=./${FNAME} nix flake check --impure
+      - name: Check flake
+        run: nix flake check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ['master']
+    branches: ["master"]
   pull_request:
-    branches: ['*']
+    branches: ["*"]
 
 env:
   GO_VERSION: 1.21.0
@@ -30,15 +30,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: 'true'
+          submodules: "true"
       - uses: dtolnay/rust-toolchain@stable
       - run: sudo apt-get install protobuf-compiler
       - name: setup go ${{ env.GO_VERSION }}
         uses: lightningnetwork/lnd/.github/actions/setup-go@v0-16-4-branch
         with:
-          go-version: '${{ env.GO_VERSION }}'
+          go-version: "${{ env.GO_VERSION }}"
       - name: run unit tests
-        run: cargo test --bin lndk 
+        run: cargo test --bin lndk
       - name: run cli unit tests
         run: cargo test --bin lndk-cli
       - name: run integration tests
@@ -63,3 +63,26 @@ jobs:
           files: lcov.info
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  check-flake:
+    name: Check Nix Flake
+    runs-on: ubuntu-latest
+    env:
+      FNAME: bitcoin-22.1-x86_64-linux-gnu.tar.gz
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Check Nix flake inputs
+        uses: DeterminateSystems/flake-checker-action@v8
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@V27
+        with:
+          nix_path: nixpkgs=channel:nixos-24.05
+      - run: echo "BITCOIND_TARBALL_FILE=./${FNAME}" >> $GITHUB_ENV
+      - run: wget -q https://bitcoincore.org/bin/bitcoin-core-22.1/${FNAME}
+      - name: Check flake (excluding integration tests)
+        run: BITCOIND_TARBALL_FILE=./${FNAME} nix flake check --impure

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /target
 lndk.conf*
 /.vscode
+
+# Ignore nix outputs
+result
+result-[0-9]*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,16 +497,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -2805,6 +2805,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ path = "src/cli.rs"
 [package.metadata.configure_me]
 spec = "config_spec.toml"
 
+[features]
+itest = ["dep:bitcoincore-rpc", "dep:corepc-node", "dep:chrono", "dep:ldk-sample"]
+
 [dependencies]
 async-trait = "0.1.66"
 bitcoin = { version = "0.30.2", features = ["rand"] }
@@ -33,11 +36,13 @@ bytes = "1.4.0"
 triggered = "0.1.2"
 prost = "0.12"
 
+# Integration test dependencies, only enabled with itest feature
+bitcoincore-rpc = { version = "0.19.0", optional = true }
+corepc-node = { version = "0.7.0", features = [ "28_0", "download"], optional = true }
+chrono = { version = "0.4.26", optional = true }
+ldk-sample = { git = "https://github.com/lndk-org/ldk-sample", rev = "57b5e50c8dc306ece28654777b1cfc4792b35df0", optional = true }
+
 [dev-dependencies]
-bitcoincore-rpc = "0.19.0"
-corepc-node = { version = "0.7.0", features = [ "28_0", "download"] }
-chrono = { version = "0.4.26" }
-ldk-sample = { git = "https://github.com/lndk-org/ldk-sample", rev = "57b5e50c8dc306ece28654777b1cfc4792b35df0" }
 mockall = "0.11.3"
 tempfile = "3.5.0"
 
@@ -49,3 +54,10 @@ tonic-build = "0.11"
 [profile.dist]
 inherits = "release"
 lto = "thin"
+
+[lints.rust.unexpected_cfgs]
+ level = "forbid"
+ # When adding a new cfg attribute, ensure that it is added to this list.
+ check-cfg = [
+ 	"cfg(itest)"
+ ]

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,12 @@
 GO_BUILD := go build
 CARGO_TEST := cargo test
 LND_PKG := github.com/lightningnetwork/lnd
+TMP_DIR=$(if ${TMPDIR},${TMPDIR},/tmp)
 
-TMP_DIR := "/tmp"
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Darwin)
-        TMP_DIR=${TMPDIR}
-endif
 
 itest:
 	@$(call print, "Building lnd for itests.")
 	git submodule update --init --recursive
 	cd lnd/cmd/lnd; $(GO_BUILD) -tags="peersrpc signrpc walletrpc dev" -o $(TMP_DIR)/lndk-tests/bin/lnd-itest$(EXEC_SUFFIX)
-	$(CARGO_TEST) --test '*' -- --test-threads=1 --nocapture
+	RUSTFLAGS="--cfg itest" $(CARGO_TEST) --features itest --test '*' -- --test-threads=1 --nocapture
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,30 @@ Rather than use the admin.macaroon with unrestricted permission to an `LND` node
 lncli bakemacaroon --save_to=<FILEPATH>/lndk.macaroon uri:/lnrpc.Lightning/GetInfo uri:/lnrpc.Lightning/ListPeers uri:/lnrpc.Lightning/SubscribePeerEvents uri:/lnrpc.Lightning/SendCustomMessage uri:/lnrpc.Lightning/SubscribeCustomMessages uri:/peersrpc.Peers/UpdateNodeAnnouncement uri:/signrpc.Signer/DeriveSharedKey uri:/verrpc.Versioner/GetVersion
 ```
 
+### Using Nix
+
+Nix is a package manager for Unix systems that makes package management reliable and reproducible.
+
+To use LNDK on Nix you first need to install [Nix](https://nixos.org/download/).
+
+Then you have few options to run or develop LNDK:
+
+`nix develop` will open a shell with all the dependencies needed to run LNDK and itests.
+`nix flake check` will run all the checks defined in the flake. Also runs cargo audit and formatting checks.
+
+
+#### Running Integration Tests
+
+Integration tests require building an LND binary. You can use Nix to provide a complete environment with all dependencies needed for the tests:
+
+```
+nix develop
+make itest
+```
+
+The integration tests must be run from within the Git repository. The script will handle building LND from source and running the tests with the correct environment variables.
+
+
 ## Security
 
 NOTE: It is recommended to always use [cargo-crev](https://github.com/crev-dev/cargo-crev)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,150 @@
+{
+  "nodes": {
+    "advisory-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1744288177,
+        "narHash": "sha256-HxYhdWc6YJ8Q8gOZtv7+teCucmDf6+Ntickvb62Au58=",
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "rev": "1273f0099ce6882659ff64b852c8fdb5f8cdd5b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "locked": {
+        "lastModified": 1744386647,
+        "narHash": "sha256-DXwQEJllxpYeVOiSlBhQuGjfvkoGHTtILLYO2FvcyzQ=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "d02c1cdd7ec539699aa44e6ff912e15535969803",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1744440957,
+        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1735554305,
+        "narHash": "sha256-zExSA1i/b+1NMRhGGLtNfFGXgLtgo+dcuzHzaWA6w3Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0e82ab234249d8eee3e8c91437802b32c74bb3fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "advisory-db": "advisory-db",
+        "crane": "crane",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1744684506,
+        "narHash": "sha256-pDPDMT1rdkTWi8MIoZ67gT3L817R7P0Jo+PP+BrnyJI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "47beae969336c05e892e1e4a9dbaac9593de34ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1743748085,
+        "narHash": "sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660+gbUU3cE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "815e4121d6a5d504c0f96e5be2dd7f871e4fd99d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,70 @@
+{
+  description = "LNDK: Standalone deamon that connects to LND that implements bolt12 funtionallities";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+
+    flake-parts.url = "github:hercules-ci/flake-parts";
+
+    crane.url = "github:ipetkov/crane";
+
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+
+    advisory-db = {
+      url = "github:rustsec/advisory-db";
+      flake = false;
+    };
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      flake-parts,
+      rust-overlay,
+      crane,
+      ...
+    }:
+    flake-parts.lib.mkFlake
+      {
+        inherit inputs;
+        specialArgs = { inherit crane; };
+      }
+      {
+        systems = nixpkgs.lib.systems.flakeExposed;
+        imports = [
+          inputs.treefmt-nix.flakeModule
+          ./nix/pkgs/flake-module.nix
+          ./nix/checks/flake-module.nix
+          ./nix/shells.nix
+          ./nix/treefmt.nix
+        ];
+        perSystem =
+          {
+            config,
+            pkgs,
+            self',
+            system,
+            ...
+          }:
+          {
+            _module.args.pkgs = import inputs.nixpkgs {
+              inherit system;
+              overlays = [ (import rust-overlay) ];
+            };
+            apps = {
+              lndk = {
+                program = "${self'.packages.lndk}/bin/lndk";
+              };
+              lndk-cli = {
+                program = "${self'.packages.lndk}/bin/lndk-cli";
+              };
+            };
+          };
+      };
+}

--- a/nix/bitcoin.nix
+++ b/nix/bitcoin.nix
@@ -1,0 +1,11 @@
+{ system, pkgs }:
+let
+  pkgs_bitcoind = import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/21808d22b1cda1898b71cf1a1beb524a97add2c4.tar.gz";
+    # Bitcoin Core 28.1
+    sha256 = "0v2z6jphhbk1ik7fqhlfnihcyff5np9wb3pv19j9qb9mpildx0cg";
+  }) { inherit system; };
+in
+{
+  bitcoind = pkgs_bitcoind.bitcoind;
+}

--- a/nix/checks/flake-module.nix
+++ b/nix/checks/flake-module.nix
@@ -1,0 +1,31 @@
+{
+  inputs,
+  self,
+  crane,
+  ...
+}:
+{
+  perSystem =
+    {
+      pkgs,
+      config,
+      system,
+      ...
+    }:
+    let
+      rustToolchainFile = builtins.fromTOML (builtins.readFile ../../rust-toolchain.toml);
+      rustChannel = rustToolchainFile.toolchain.channel;
+      craneLib = (crane.mkLib pkgs).overrideToolchain (pkgs.rust-bin.stable.${rustChannel}.default);
+      advisory-db = inputs.advisory-db;
+    in
+    {
+      checks = {
+        lndk = config.packages.rust;
+        cargo-audit = craneLib.cargoAudit {
+          src = ../../.;
+          inherit advisory-db;
+        };
+        formatting = config.treefmt.build.check self;
+      };
+    };
+}

--- a/nix/pkgs/flake-module.nix
+++ b/nix/pkgs/flake-module.nix
@@ -1,0 +1,20 @@
+{
+  self,
+  inputs,
+  crane,
+  ...
+}:
+{
+  perSystem =
+    { system, pkgs, ... }:
+    let
+      rustPackages = import ./rust.nix { inherit pkgs inputs crane; };
+    in
+    {
+      packages = {
+        inherit (rustPackages) rust;
+        lndk = rustPackages.rust; # Alias for consistency
+        default = rustPackages.rust;
+      };
+    };
+}

--- a/nix/pkgs/rust.nix
+++ b/nix/pkgs/rust.nix
@@ -1,0 +1,51 @@
+{
+  pkgs,
+  inputs,
+  crane,
+  ...
+}:
+
+let
+  inherit (pkgs) lib stdenv;
+  src = ../../.;
+  rustToolchainFile = builtins.fromTOML (builtins.readFile ../../rust-toolchain.toml);
+  rustChannel = rustToolchainFile.toolchain.channel;
+  craneLib = (crane.mkLib pkgs).overrideToolchain (pkgs.rust-bin.stable.${rustChannel}.default);
+  commonDeps = {
+    nativeBuildInputs = with pkgs; [
+      pkg-config
+      protobuf
+    ];
+
+    buildInputs = with pkgs; [
+      openssl
+    ];
+  };
+
+  cargoArtifacts = craneLib.buildDepsOnly {
+    inherit src;
+    pname = "lndk-deps";
+    inherit (commonDeps) nativeBuildInputs buildInputs;
+  };
+
+  basePkg = {
+    inherit src cargoArtifacts;
+    inherit (commonDeps) nativeBuildInputs buildInputs;
+
+    meta = with lib; {
+      description = "Standalone daemon that connects to LND to implement bolt12 functionalities";
+      homepage = "https://github.com/lndk-org/lndk";
+      license = licenses.mit;
+      platforms = platforms.linux ++ platforms.darwin;
+    };
+  };
+
+  lndkPkg = craneLib.buildPackage (
+    basePkg
+    // {
+      pname = "lndk";
+
+in
+{
+  rust = lndkPkg;
+}

--- a/nix/pkgs/rust.nix
+++ b/nix/pkgs/rust.nix
@@ -44,6 +44,8 @@ let
     basePkg
     // {
       pname = "lndk";
+    }
+  );
 
 in
 {

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -1,0 +1,41 @@
+{ self, crane, ... }:
+{
+  perSystem =
+    {
+      config,
+      pkgs,
+      system,
+      ...
+    }:
+    let
+      rustToolchainFile = builtins.fromTOML (builtins.readFile ../rust-toolchain.toml);
+      rustChannel = rustToolchainFile.toolchain.channel;
+      bitcoinPkgs = import ./bitcoin.nix { inherit system pkgs; };
+    in
+    {
+      devShells = {
+        default = pkgs.mkShell {
+          packages = [
+            pkgs.rust-bin.stable.${rustChannel}.rust-analyzer
+            bitcoinPkgs.bitcoind
+          ];
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            protobuf
+            openssl
+            openssl.dev
+            rust-bin.stable.${rustChannel}.default
+            go
+            git
+          ];
+
+          shellHook = ''
+            echo "LNDK development environment loaded with Rust toolchain $(rustc --version)"
+            export BITCOIND_EXE="${bitcoinPkgs.bitcoind}/bin/bitcoind"
+            export BITCOIND_SKIP_DOWNLOAD="TRUE"
+          '';
+        };
+      };
+    };
+}

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -1,0 +1,12 @@
+{ ... }:
+{
+  perSystem =
+    { pkgs, lib, ... }:
+    {
+      treefmt = {
+        projectRootFile = "flake.nix";
+        programs.nixfmt.enable = true;
+        programs.rustfmt.enable = true;
+      };
+    };
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -11,6 +11,7 @@ use ldk_sample::node_api::Node as LdkNode;
 use lightning::util::logger::Level;
 use lndk::lnd::validate_lnd_creds;
 use lndk::{setup_logger, LifecycleSignals, LndkOnionMessenger, OfferHandler};
+use std::fs::File;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
@@ -358,11 +359,18 @@ impl LndNode {
             format!("--protocol.custom-init=39"),
         ];
 
+        let stdout_log_path = lnd_data_dir.join("lnd-itest-stdout.log");
+        let stderr_log_path = lnd_data_dir.join("lnd-itest-stderr.log");
+        let stdout_file =
+            File::create(&stdout_log_path).expect("Failed to create stdout log file for lnd-itest");
+        let stderr_file =
+            File::create(&stderr_log_path).expect("Failed to create stderr log file for lnd-itest");
+
         // TODO: For Windows we might need to add ".exe" at the end.
         let cmd = Command::new("./lnd-itest")
             .args(args)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stdout(Stdio::from(stdout_file))
+            .stderr(Stdio::from(stderr_file))
             .spawn()
             .expect("Failed to execute lnd command");
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(itest)]
+
 mod common;
 use futures::future::try_join_all;
 use lndk;


### PR DESCRIPTION
This PR adds a simple nix flake heavily inspired on [CLN](https://github.com/ElementsProject/lightning/pull/7656) one.

Few commands that now can be used

`nix develop` create a shell environment with all dependencies for development
`nix build`  or `nix build .#lndk` builds the projects to have executables `lndk and lndk-cli`
`nix flake check` checks formatting, tests and cargo audit. Does not check integration test.

Also add a check (without integrations) for nix on CI