### PR TITLE
chore: upgrade lnd submodule and bitcoind on itests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2106,7 +2106,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.0",
+ "bitcoin_hashes 0.12.0",
  "rand 0.8.5",
  "secp256k1-sys 0.10.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ prost = "0.12"
 
 [dev-dependencies]
 bitcoincore-rpc = "0.19.0"
-corepc-node = { version = "0.7.0", features = [ "27_2", "download"] }
+corepc-node = { version = "0.7.0", features = [ "28_0", "download"] }
 chrono = { version = "0.4.26" }
 ldk-sample = { git = "https://github.com/lndk-org/ldk-sample", rev = "57b5e50c8dc306ece28654777b1cfc4792b35df0" }
 mockall = "0.11.3"


### PR DESCRIPTION
This PR is on top of #209 

In order to use latest bitcoind supported on corepc-node crate we need to update lnd.
This PR then upgrades lnd submodule to 0.18.5-beta and then upgrades itest to use bitcoind 28_0