### PR TITLE
ExpandedKey from lnd signature messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,9 +304,12 @@ pub struct PayOfferParams {
 }
 
 impl OfferHandler {
-    pub fn new(response_invoice_timeout: Option<u32>) -> Self {
+    pub fn new(response_invoice_timeout: Option<u32>, seed: Option<[u8; 32]>) -> Self {
         let messenger_utils = MessengerUtilities::default();
-        let random_bytes = messenger_utils.get_secure_random_bytes();
+        let random_bytes = match seed {
+            Some(seed) => seed,
+            None => messenger_utils.get_secure_random_bytes(),
+        };
         let expanded_key = ExpandedKey::new(random_bytes);
         let response_invoice_timeout =
             response_invoice_timeout.unwrap_or(DEFAULT_RESPONSE_INVOICE_TIMEOUT);
@@ -459,7 +462,7 @@ impl OfferHandler {
 
 impl Default for OfferHandler {
     fn default() -> Self {
-        Self::new(None)
+        Self::new(None, None)
     }
 }
 


### PR DESCRIPTION
Based on [Matt's reply](https://github.com/lndk-org/lndk/issues/170#issuecomment-2886816019) on generating offers and receiving payments. This PR sits on top of #212 that already made changes on how we sign InvoiceRequests.

On 143edb505d9f6057837404346abd7e046bd1dff0 we change how ExpandedKey, key used on signatures and verifications, is generated. From a random-bytes to a deterministic way of doing it.

1. We define a static family key and index key
2. We sign a specific message: "LNDK:DO NOT SIGN THIS MANUALLY:SEED" Based on  [bLip 0050](https://github.com/lightning/blips/blob/master/blip-0050.md#link-lsps0ln_signature)
3. We hash the result of the signature and use it as a seed for the ExpandedKey


## Key difference with master
1. Do not generate expanded key out of randomness every startup
2. Remove some of unused functions of traits

This is a baby step on receiving payments issue #170 