### PR TITLE
Create offer and receive payments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,6 @@ dependencies = [
  "bitcoin-io",
  "bitcoin-units",
  "bitcoin_hashes",
- "bitcoinconsensus",
  "hex-conservative",
  "hex_lit",
  "secp256k1",
@@ -358,15 +357,6 @@ dependencies = [
  "bitcoin-io",
  "hex-conservative",
  "serde",
-]
-
-[[package]]
-name = "bitcoinconsensus"
-version = "0.105.0+25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f260ac8fb2c621329013fc0ed371c940fcc512552dcbcb9095ed0179098c9e18"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1188,7 +1178,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "ldk-sample"
 version = "0.1.0"
-source = "git+https://github.com/lndk-org/ldk-sample?rev=07a3841bf3b6251cbcc57d8f13ea6083ac74b6dc#07a3841bf3b6251cbcc57d8f13ea6083ac74b6dc"
+source = "git+https://github.com/a-mpch/ldk-sample?branch=2025-06-use-forked-ldk#706d9e32a1b2e5d18b8e22cfce8ab1775a5cf50a"
 dependencies = [
  "base64 0.13.1",
  "bech32 0.8.1",
@@ -1226,8 +1216,7 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 [[package]]
 name = "lightning"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad202bfb8960e3043d167d507693b0ca853e727cf93ad0ba4b3663cc08b54eda"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
 dependencies = [
  "bech32 0.11.0",
  "bitcoin",
@@ -1236,15 +1225,14 @@ dependencies = [
  "libm",
  "lightning-invoice",
  "lightning-types",
+ "musig2",
  "possiblyrandom",
- "regex",
 ]
 
 [[package]]
 name = "lightning-background-processor"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04231b97fd7509d73ce9857a416eb1477a55d076d4e22cbf26c649a772bde909"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
@@ -1256,8 +1244,7 @@ dependencies = [
 [[package]]
 name = "lightning-block-sync"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baab5bdee174a2047d939a4ca0dc2e1c23caa0f8cab0b4380aed77a20e116f1e"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
 dependencies = [
  "bitcoin",
  "chunked_transfer",
@@ -1269,8 +1256,7 @@ dependencies = [
 [[package]]
 name = "lightning-dns-resolver"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74e3e12284b661620e832b27adf8aa2d55027052a8cd5f0392a990fbd75bb9c"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
 dependencies = [
  "dnssec-prover",
  "lightning",
@@ -1281,8 +1267,7 @@ dependencies = [
 [[package]]
 name = "lightning-invoice"
 version = "0.33.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
 dependencies = [
  "bech32 0.11.0",
  "bitcoin",
@@ -1292,8 +1277,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6a6c93b1e592f1d46bb24233cac4a33b4015c99488ee229927a81d16226e45"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1303,8 +1287,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80558dc398eb4609b1079044d8eb5760a58724627ff57c6d7c194c78906e026"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1314,8 +1297,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78dacdef3e2f5d727754f902f4e6bbc43bfc886fec8e71f36757711060916ebe"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
@@ -1326,8 +1308,7 @@ dependencies = [
 [[package]]
 name = "lightning-types"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
 dependencies = [
  "bitcoin",
 ]
@@ -1527,6 +1508,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
+name = "musig2"
+version = "0.1.0"
+source = "git+https://github.com/arik-so/rust-musig2?rev=6f95a05718cbb44d8fe3fa6021aea8117aa38d50#6f95a05718cbb44d8fe3fa6021aea8117aa38d50"
+dependencies = [
+ "bitcoin",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,8 +1710,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 [[package]]
 name = "possiblyrandom"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b122a615d72104fb3d8b26523fdf9232cd8ee06949fb37e4ce3ff964d15dffd"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
 dependencies = [
  "getrandom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,7 +1216,7 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 [[package]]
 name = "lightning"
 version = "0.1.3"
-source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#878619b2a95af44a5c5ab811805ae41846fb0cc4"
 dependencies = [
  "bech32 0.11.0",
  "bitcoin",
@@ -1232,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.1.0"
-source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#878619b2a95af44a5c5ab811805ae41846fb0cc4"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
@@ -1244,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "lightning-block-sync"
 version = "0.1.0"
-source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#878619b2a95af44a5c5ab811805ae41846fb0cc4"
 dependencies = [
  "bitcoin",
  "chunked_transfer",
@@ -1256,7 +1256,7 @@ dependencies = [
 [[package]]
 name = "lightning-dns-resolver"
 version = "0.2.0"
-source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#878619b2a95af44a5c5ab811805ae41846fb0cc4"
 dependencies = [
  "dnssec-prover",
  "lightning",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "lightning-invoice"
 version = "0.33.2"
-source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#878619b2a95af44a5c5ab811805ae41846fb0cc4"
 dependencies = [
  "bech32 0.11.0",
  "bitcoin",
@@ -1277,7 +1277,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.1.0"
-source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#878619b2a95af44a5c5ab811805ae41846fb0cc4"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1287,7 +1287,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.1.0"
-source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#878619b2a95af44a5c5ab811805ae41846fb0cc4"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1297,7 +1297,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.1.0"
-source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#878619b2a95af44a5c5ab811805ae41846fb0cc4"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
@@ -1308,7 +1308,7 @@ dependencies = [
 [[package]]
 name = "lightning-types"
 version = "0.2.0"
-source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#878619b2a95af44a5c5ab811805ae41846fb0cc4"
 dependencies = [
  "bitcoin",
 ]
@@ -1710,7 +1710,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 [[package]]
 name = "possiblyrandom"
 version = "0.2.0"
-source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#8a0a6ce36e12f8a503cc1cd644148cfa6a2ebbe2"
+source = "git+https://github.com/a-mpch/rust-lightning?branch=2025-06-cherry-pick-exposed#878619b2a95af44a5c5ab811805ae41846fb0cc4"
 dependencies = [
  "getrandom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,12 @@ bitcoin = { version = "0.32.6", features = ["rand"] }
 clap = { version = "4.4.6", features = ["derive", "string"] }
 futures = "0.3.26"
 home = "0.5.5"
-lightning = { version = "0.1.3", features = ["_test_utils"] }
+# lightning = { version = "0.1.3", features = ["_test_utils"] }
+# Branch port commit https://github.com/lightningdevkit/rust-lightning/commit/928429833507eb98b1f9a3793da4fe4527e11435
+# from main branch on top of version 0.1.3.
+# TODO: Use main crate when version 0.2.X is deployed.
+lightning = { git = "https://github.com/a-mpch/rust-lightning", branch = "2025-06-cherry-pick-exposed", features = ["dnssec"] }
+
 rand_chacha = "0.3.1"
 rand_core = "0.6.4"
 log = "0.4.17"
@@ -41,7 +46,7 @@ async_fn_traits = "0.1.1"
 bitcoincore-rpc = { version = "0.19.0", optional = true }
 corepc-node = { version = "0.7.0", features = [ "28_0", "download"], optional = true }
 chrono = { version = "0.4.26", optional = true }
-ldk-sample = { git = "https://github.com/lndk-org/ldk-sample", rev = "07a3841bf3b6251cbcc57d8f13ea6083ac74b6dc", optional = true }
+ldk-sample = { git = "https://github.com/a-mpch/ldk-sample", branch = "2025-06-use-forked-ldk", optional = true }
 
 [dev-dependencies]
 mockall = "0.11.3"

--- a/proto/lndkrpc.proto
+++ b/proto/lndkrpc.proto
@@ -6,6 +6,7 @@ service Offers {
     rpc GetInvoice (GetInvoiceRequest) returns (GetInvoiceResponse);
     rpc DecodeInvoice (DecodeInvoiceRequest) returns (Bolt12InvoiceContents);
     rpc PayInvoice (PayInvoiceRequest) returns (PayInvoiceResponse);
+    rpc CreateOffer (CreateOfferRequest) returns (CreateOfferResponse);
 }
 
 message PayOfferRequest {
@@ -139,4 +140,17 @@ enum FeatureBit {
     ROUTE_BLINDING_OPTIONAL = 25;
     AMP_REQ = 30;
     AMP_OPT = 31;
+}
+
+message CreateOfferRequest {
+    optional uint64 amount = 1;
+    optional string description = 2;
+    optional string issuer = 3;
+    optional uint64 quantity = 4;
+    optional uint64 expiry = 5;
+}
+
+
+message CreateOfferResponse {
+    string offer = 1;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod clock;
 mod grpc;
 #[allow(dead_code)]
 pub mod lnd;
+mod message_router;
 pub mod offers;
 pub mod onion_messenger;
 mod rate_limit;
@@ -31,6 +32,7 @@ use log4rs::append::console::ConsoleAppender;
 use log4rs::append::file::FileAppender;
 use log4rs::config::{Appender, Config as LogConfig, Logger, Root};
 use log4rs::encode::pattern::PatternEncoder;
+use message_router::MessageRouter;
 use offers::handler::OfferHandler;
 use rate_limit::RateLimiterCfg;
 use std::path::PathBuf;
@@ -190,7 +192,9 @@ impl LndkOnionMessenger {
         let node_signer = LndNodeSigner::new(pubkey, &mut node_client);
         let messenger_utils = MessengerUtilities::default();
         let network_graph = &NetworkGraph::new(network, &messenger_utils);
-        let message_router = &DefaultMessageRouter::new(network_graph, &messenger_utils);
+        let default_message_router = DefaultMessageRouter::new(network_graph, &messenger_utils);
+        let message_router =
+            &MessageRouter::new(default_message_router, client.clone().lightning_read_only());
         let node_id_lookup = LndkNodeIdLookUp::new(client.clone(), pubkey);
         let onion_messenger = OnionMessenger::new(
             &messenger_utils,

--- a/src/lnd.rs
+++ b/src/lnd.rs
@@ -459,6 +459,10 @@ pub trait InvoicePayer {
     async fn track_payment(&mut self, payment_hash: [u8; 32]) -> Result<Payment, OfferError>;
 }
 
+#[async_trait]
+pub trait OfferCreator {
+    async fn get_info(&mut self) -> Result<GetInfoResponse, Status>;
+}
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,7 @@ async fn main() -> Result<(), ()> {
     let handler = Arc::new(OfferHandler::new(
         config.response_invoice_timeout,
         Some(seed),
+        Some(client.clone()),
     ));
     let messenger = LndkOnionMessenger::new();
 

--- a/src/message_router.rs
+++ b/src/message_router.rs
@@ -1,0 +1,593 @@
+use bitcoin::secp256k1::{PublicKey, Secp256k1};
+use futures::executor::block_on;
+use lightning::blinded_path::message::{BlindedMessagePath, MessageContext};
+use lightning::blinded_path::IntroductionNode;
+use lightning::ln::msgs::SocketAddress;
+use lightning::onion_message::messenger::{
+    Destination, MessageRouter as LightningMessageRouter, OnionMessagePath,
+};
+use std::cell::RefCell;
+use std::str::FromStr;
+
+use crate::lnd::{features_support_onion_messages, PeerConnector};
+
+pub struct MessageRouter<MR: LightningMessageRouter, C: PeerConnector> {
+    inner_message_router: MR,
+    client: RefCell<C>,
+}
+
+impl<MR: LightningMessageRouter, C: PeerConnector> MessageRouter<MR, C> {
+    pub fn new(inner_message_router: MR, client: C) -> Self {
+        Self {
+            inner_message_router,
+            // We use RefCell to allow the client to be borrowed mutably because
+            // find_path trait requires that self is not mutable.
+            client: RefCell::new(client),
+        }
+    }
+
+    fn get_first_node(&self, destination: &Destination) -> Option<PublicKey> {
+        match destination {
+            Destination::Node(node_id) => Some(*node_id),
+            Destination::BlindedPath(path) => match path.introduction_node() {
+                IntroductionNode::NodeId(pubkey) => Some(*pubkey),
+                IntroductionNode::DirectedShortChannelId(..) => None,
+            },
+        }
+    }
+}
+
+impl<MR: LightningMessageRouter, C: PeerConnector> LightningMessageRouter for MessageRouter<MR, C> {
+    fn find_path(
+        &self,
+        sender: PublicKey,
+        peers: Vec<PublicKey>,
+        destination: Destination,
+    ) -> Result<OnionMessagePath, ()> {
+        let first_node = match self.get_first_node(&destination) {
+            Some(first_node) => first_node,
+            None => return Err(()),
+        };
+
+        if peers.contains(&first_node) || sender == first_node {
+            Ok(OnionMessagePath {
+                intermediate_nodes: vec![],
+                destination,
+                first_node_addresses: None,
+            })
+        } else {
+            let node_info = block_on(
+                self.client
+                    .borrow_mut()
+                    .get_node_info(first_node.to_string(), false),
+            )
+            .map_err(|_| ())?;
+
+            match node_info.node {
+                Some(node)
+                    if !node.addresses.is_empty()
+                        && features_support_onion_messages(&node.features) =>
+                {
+                    let addresses: Vec<SocketAddress> = node
+                        .addresses
+                        .iter()
+                        .filter_map(|addr| SocketAddress::from_str(&addr.addr).ok())
+                        .collect();
+
+                    if addresses.is_empty() {
+                        return Err(());
+                    }
+
+                    Ok(OnionMessagePath {
+                        intermediate_nodes: vec![],
+                        destination,
+                        first_node_addresses: Some(addresses),
+                    })
+                }
+                _ => Err(()),
+            }
+        }
+    }
+
+    fn create_blinded_paths<T: bitcoin::secp256k1::Signing + bitcoin::secp256k1::Verification>(
+        &self,
+        recipient: PublicKey,
+        context: MessageContext,
+        peers: Vec<PublicKey>,
+        secp_ctx: &Secp256k1<T>,
+    ) -> Result<Vec<BlindedMessagePath>, ()> {
+        self.inner_message_router
+            .create_blinded_paths(recipient, context, peers, secp_ctx)
+    }
+
+    fn create_compact_blinded_paths<
+        T: bitcoin::secp256k1::Signing + bitcoin::secp256k1::Verification,
+    >(
+        &self,
+        recipient: PublicKey,
+        context: MessageContext,
+        peers: Vec<lightning::blinded_path::message::MessageForwardNode>,
+        secp_ctx: &Secp256k1<T>,
+    ) -> Result<Vec<BlindedMessagePath>, ()> {
+        let peers = peers
+            .into_iter()
+            .map(
+                |lightning::blinded_path::message::MessageForwardNode {
+                     node_id,
+                     short_channel_id: _,
+                 }| node_id,
+            )
+            .collect();
+        self.create_blinded_paths(recipient, context, peers, secp_ctx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::secp256k1::{Secp256k1, SecretKey};
+    use mockall::mock;
+    use std::sync::{Arc, Mutex};
+
+    // We manually implement the LigthtningMessageRouter mock as it
+    // was simpler to implement than to use the mockall crate.
+    struct MockMessageRouter {
+        create_blinded_paths_calls: Arc<Mutex<u32>>,
+        create_blinded_paths_result: Result<Vec<BlindedMessagePath>, ()>,
+    }
+
+    impl MockMessageRouter {
+        fn new(result: Result<Vec<BlindedMessagePath>, ()>) -> Self {
+            Self {
+                create_blinded_paths_calls: Arc::new(Mutex::new(0)),
+                create_blinded_paths_result: result,
+            }
+        }
+
+        fn create_blinded_paths_call_count(&self) -> u32 {
+            *self.create_blinded_paths_calls.lock().unwrap()
+        }
+    }
+
+    impl LightningMessageRouter for MockMessageRouter {
+        fn find_path(
+            &self,
+            _sender: PublicKey,
+            _peers: Vec<PublicKey>,
+            _destination: Destination,
+        ) -> Result<OnionMessagePath, ()> {
+            Err(())
+        }
+
+        fn create_blinded_paths<
+            T: bitcoin::secp256k1::Signing + bitcoin::secp256k1::Verification,
+        >(
+            &self,
+            _recipient: PublicKey,
+            _context: MessageContext,
+            _peers: Vec<PublicKey>,
+            _secp_ctx: &Secp256k1<T>,
+        ) -> Result<Vec<BlindedMessagePath>, ()> {
+            *self.create_blinded_paths_calls.lock().unwrap() += 1;
+            self.create_blinded_paths_result.clone()
+        }
+    }
+
+    mock! {
+        pub TestPeerConnector {}
+
+        #[async_trait::async_trait]
+        impl PeerConnector for TestPeerConnector {
+            async fn list_peers(&mut self) -> Result<tonic_lnd::lnrpc::ListPeersResponse, tonic_lnd::tonic::Status>;
+            async fn connect_peer(&mut self, node_id: String, addr: String) -> Result<(), tonic_lnd::tonic::Status>;
+            async fn get_node_info(&mut self, pub_key: String, include_channels: bool) -> Result<tonic_lnd::lnrpc::NodeInfo, tonic_lnd::tonic::Status>;
+        }
+    }
+
+    fn create_secp_ctx() -> Secp256k1<bitcoin::secp256k1::All> {
+        Secp256k1::new()
+    }
+
+    #[test]
+    fn test_create_blinded_paths_calls_inner_router() {
+        let mock_router = MockMessageRouter::new(Ok(vec![]));
+        let mock_client = MockTestPeerConnector::new();
+
+        let secp_ctx = Secp256k1::new();
+
+        // Create test recipient
+        let recipient_secret = SecretKey::from_slice(&[1; 32]).unwrap();
+        let recipient = PublicKey::from_secret_key(&secp_ctx, &recipient_secret);
+
+        // Create test peer
+        let peer_secret = SecretKey::from_slice(&[2; 32]).unwrap();
+        let peer_node_id = PublicKey::from_secret_key(&secp_ctx, &peer_secret);
+        let peers = vec![peer_node_id];
+
+        let context = MessageContext::Custom(vec![]);
+
+        let message_router = MessageRouter::new(mock_router, mock_client);
+
+        // Call create_blinded_paths
+        let result = message_router.create_blinded_paths(recipient, context, peers, &secp_ctx);
+
+        // Verify that the inner router was called exactly once
+        assert_eq!(
+            message_router
+                .inner_message_router
+                .create_blinded_paths_call_count(),
+            1
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_create_blinded_paths_forwards_error() {
+        let mock_router = MockMessageRouter::new(Err(()));
+        let mock_client = MockTestPeerConnector::new();
+
+        let secp_ctx = Secp256k1::new();
+
+        // Create test recipient
+        let recipient_secret = SecretKey::from_slice(&[1; 32]).unwrap();
+        let recipient = PublicKey::from_secret_key(&secp_ctx, &recipient_secret);
+
+        let peers = vec![];
+        let context = MessageContext::Custom(vec![]);
+
+        let message_router = MessageRouter::new(mock_router, mock_client);
+
+        // Call create_blinded_paths
+        let result = message_router.create_blinded_paths(recipient, context, peers, &secp_ctx);
+
+        // Verify that the inner router was called and the error was forwarded
+        assert_eq!(
+            message_router
+                .inner_message_router
+                .create_blinded_paths_call_count(),
+            1
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_first_node_with_node_destination() {
+        let mock_router = MockMessageRouter::new(Ok(vec![]));
+        let mock_client = MockTestPeerConnector::new();
+        let message_router = MessageRouter::new(mock_router, mock_client);
+
+        let secp_ctx = create_secp_ctx();
+        let node_secret = SecretKey::from_slice(&[1; 32]).unwrap();
+        let node_pubkey = PublicKey::from_secret_key(&secp_ctx, &node_secret);
+        let destination = Destination::Node(node_pubkey);
+
+        let first_node = message_router.get_first_node(&destination);
+        assert_eq!(first_node, Some(node_pubkey));
+    }
+
+    // Test the DirectedShortChannelId case by testing get_first_node function directly
+    // This is simpler than creating a full BlindedMessagePath with DirectedShortChannelId
+    // For now we test other cases that are easier to implement
+
+    #[test]
+    fn test_find_path_sender_equals_first_node() {
+        let mock_router = MockMessageRouter::new(Ok(vec![]));
+        let mock_client = MockTestPeerConnector::new();
+        let message_router = MessageRouter::new(mock_router, mock_client);
+
+        let secp_ctx = create_secp_ctx();
+
+        let sender_secret = SecretKey::from_slice(&[3; 32]).unwrap();
+        let sender = PublicKey::from_secret_key(&secp_ctx, &sender_secret);
+
+        // Use the same key as sender for destination
+        let destination = Destination::Node(sender);
+
+        let peers = vec![];
+
+        let result = message_router.find_path(sender, peers, destination);
+        assert!(result.is_ok());
+
+        let path = result.unwrap();
+        assert!(path.intermediate_nodes.is_empty());
+        assert!(path.first_node_addresses.is_none());
+    }
+
+    #[test]
+    fn test_find_path_peers_contains_first_node() {
+        let mock_router = MockMessageRouter::new(Ok(vec![]));
+        let mock_client = MockTestPeerConnector::new();
+        let message_router = MessageRouter::new(mock_router, mock_client);
+
+        let secp_ctx = create_secp_ctx();
+
+        let sender_secret = SecretKey::from_slice(&[3; 32]).unwrap();
+        let sender = PublicKey::from_secret_key(&secp_ctx, &sender_secret);
+
+        let destination_secret = SecretKey::from_slice(&[4; 32]).unwrap();
+        let destination_node = PublicKey::from_secret_key(&secp_ctx, &destination_secret);
+        let destination = Destination::Node(destination_node);
+
+        // Include destination node in peers
+        let peers = vec![destination_node];
+
+        let result = message_router.find_path(sender, peers, destination);
+        assert!(result.is_ok());
+
+        let path = result.unwrap();
+        assert!(path.intermediate_nodes.is_empty());
+        assert!(path.first_node_addresses.is_none());
+    }
+
+    #[test]
+    fn test_find_path_get_node_info_returns_error() {
+        let mock_router = MockMessageRouter::new(Ok(vec![]));
+        let mut mock_client = MockTestPeerConnector::new();
+
+        // Mock get_node_info to return an error
+        mock_client
+            .expect_get_node_info()
+            .once()
+            .returning(|_, _| Err(tonic_lnd::tonic::Status::not_found("Node not found")));
+
+        let message_router = MessageRouter::new(mock_router, mock_client);
+
+        let secp_ctx = create_secp_ctx();
+
+        let sender_secret = SecretKey::from_slice(&[3; 32]).unwrap();
+        let sender = PublicKey::from_secret_key(&secp_ctx, &sender_secret);
+
+        let destination_secret = SecretKey::from_slice(&[4; 32]).unwrap();
+        let destination_node = PublicKey::from_secret_key(&secp_ctx, &destination_secret);
+        let destination = Destination::Node(destination_node);
+
+        let peers = vec![]; // Empty peers, so it will try get_node_info
+
+        let result = message_router.find_path(sender, peers, destination);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_find_path_node_info_returns_none_for_node() {
+        let mock_router = MockMessageRouter::new(Ok(vec![]));
+        let mut mock_client = MockTestPeerConnector::new();
+
+        // Mock get_node_info to return NodeInfo with None node
+        mock_client.expect_get_node_info().once().returning(|_, _| {
+            Ok(tonic_lnd::lnrpc::NodeInfo {
+                node: None,
+                num_channels: 0,
+                total_capacity: 0,
+                channels: vec![],
+            })
+        });
+
+        let message_router = MessageRouter::new(mock_router, mock_client);
+
+        let secp_ctx = create_secp_ctx();
+
+        let sender_secret = SecretKey::from_slice(&[3; 32]).unwrap();
+        let sender = PublicKey::from_secret_key(&secp_ctx, &sender_secret);
+
+        let destination_secret = SecretKey::from_slice(&[4; 32]).unwrap();
+        let destination_node = PublicKey::from_secret_key(&secp_ctx, &destination_secret);
+        let destination = Destination::Node(destination_node);
+
+        let peers = vec![]; // Empty peers, so it will try get_node_info
+
+        let result = message_router.find_path(sender, peers, destination);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_find_path_node_without_addresses() {
+        let mock_router = MockMessageRouter::new(Ok(vec![]));
+        let mut mock_client = MockTestPeerConnector::new();
+
+        // Mock get_node_info to return node with empty addresses
+        mock_client.expect_get_node_info().once().returning(|_, _| {
+            Ok(tonic_lnd::lnrpc::NodeInfo {
+                node: Some(tonic_lnd::lnrpc::LightningNode {
+                    last_update: 0,
+                    pub_key: "".to_string(),
+                    alias: "".to_string(),
+                    addresses: vec![], // Empty addresses
+                    color: "".to_string(),
+                    features: std::collections::HashMap::new(),
+                    custom_records: std::collections::HashMap::new(),
+                }),
+                num_channels: 0,
+                total_capacity: 0,
+                channels: vec![],
+            })
+        });
+
+        let message_router = MessageRouter::new(mock_router, mock_client);
+
+        let secp_ctx = create_secp_ctx();
+
+        let sender_secret = SecretKey::from_slice(&[3; 32]).unwrap();
+        let sender = PublicKey::from_secret_key(&secp_ctx, &sender_secret);
+
+        let destination_secret = SecretKey::from_slice(&[4; 32]).unwrap();
+        let destination_node = PublicKey::from_secret_key(&secp_ctx, &destination_secret);
+        let destination = Destination::Node(destination_node);
+
+        let peers = vec![];
+
+        let result = message_router.find_path(sender, peers, destination);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_find_path_node_without_onion_message_features() {
+        let mock_router = MockMessageRouter::new(Ok(vec![]));
+        let mut mock_client = MockTestPeerConnector::new();
+
+        // Mock get_node_info to return node without onion message features
+        mock_client.expect_get_node_info().once().returning(|_, _| {
+            Ok(tonic_lnd::lnrpc::NodeInfo {
+                node: Some(tonic_lnd::lnrpc::LightningNode {
+                    last_update: 0,
+                    pub_key: "".to_string(),
+                    alias: "".to_string(),
+                    addresses: vec![tonic_lnd::lnrpc::NodeAddress {
+                        network: "tcp".to_string(),
+                        addr: "127.0.0.1:9735".to_string(),
+                    }],
+                    color: "".to_string(),
+                    features: std::collections::HashMap::new(), /* Empty features (no onion
+                                                                 * message support) */
+                    custom_records: std::collections::HashMap::new(),
+                }),
+                num_channels: 0,
+                total_capacity: 0,
+                channels: vec![],
+            })
+        });
+
+        let message_router = MessageRouter::new(mock_router, mock_client);
+
+        let secp_ctx = create_secp_ctx();
+
+        let sender_secret = SecretKey::from_slice(&[3; 32]).unwrap();
+        let sender = PublicKey::from_secret_key(&secp_ctx, &sender_secret);
+
+        let destination_secret = SecretKey::from_slice(&[4; 32]).unwrap();
+        let destination_node = PublicKey::from_secret_key(&secp_ctx, &destination_secret);
+        let destination = Destination::Node(destination_node);
+
+        let peers = vec![];
+
+        let result = message_router.find_path(sender, peers, destination);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_find_path_node_with_unparseable_addresses() {
+        let mock_router = MockMessageRouter::new(Ok(vec![]));
+        let mut mock_client = MockTestPeerConnector::new();
+
+        // Mock get_node_info to return node with onion message features but unparseable addresses
+        mock_client.expect_get_node_info().once().returning(|_, _| {
+            let mut features = std::collections::HashMap::new();
+            // Add onion message feature (feature bit 38/39)
+            features.insert(
+                38,
+                tonic_lnd::lnrpc::Feature {
+                    name: "onion_messages_optional".to_string(),
+                    is_required: false,
+                    is_known: true,
+                },
+            );
+
+            Ok(tonic_lnd::lnrpc::NodeInfo {
+                node: Some(tonic_lnd::lnrpc::LightningNode {
+                    last_update: 0,
+                    pub_key: "".to_string(),
+                    alias: "".to_string(),
+                    addresses: vec![tonic_lnd::lnrpc::NodeAddress {
+                        network: "tcp".to_string(),
+                        addr: "invalid-address".to_string(), // Unparseable address
+                    }],
+                    color: "".to_string(),
+                    features,
+                    custom_records: std::collections::HashMap::new(),
+                }),
+                num_channels: 0,
+                total_capacity: 0,
+                channels: vec![],
+            })
+        });
+
+        let message_router = MessageRouter::new(mock_router, mock_client);
+
+        let secp_ctx = create_secp_ctx();
+
+        let sender_secret = SecretKey::from_slice(&[3; 32]).unwrap();
+        let sender = PublicKey::from_secret_key(&secp_ctx, &sender_secret);
+
+        let destination_secret = SecretKey::from_slice(&[4; 32]).unwrap();
+        let destination_node = PublicKey::from_secret_key(&secp_ctx, &destination_secret);
+        let destination = Destination::Node(destination_node);
+
+        let peers = vec![];
+
+        let result = message_router.find_path(sender, peers, destination);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_find_path_happy_path() {
+        let mock_router = MockMessageRouter::new(Ok(vec![]));
+        let mut mock_client = MockTestPeerConnector::new();
+
+        // Mock get_node_info to return node with onion message features and parseable addresses
+        mock_client.expect_get_node_info().once().returning(|_, _| {
+            let mut features = std::collections::HashMap::new();
+            // Add onion message feature (feature bit 38/39)
+            features.insert(
+                38,
+                tonic_lnd::lnrpc::Feature {
+                    name: "onion_messages_optional".to_string(),
+                    is_required: false,
+                    is_known: true,
+                },
+            );
+
+            Ok(tonic_lnd::lnrpc::NodeInfo {
+                node: Some(tonic_lnd::lnrpc::LightningNode {
+                    last_update: 0,
+                    pub_key: "".to_string(),
+                    alias: "".to_string(),
+                    addresses: vec![
+                        tonic_lnd::lnrpc::NodeAddress {
+                            network: "tcp".to_string(),
+                            addr: "127.0.0.1:9735".to_string(),
+                        },
+                        tonic_lnd::lnrpc::NodeAddress {
+                            network: "tcp".to_string(),
+                            addr: "[::1]:9735".to_string(),
+                        },
+                    ],
+                    color: "".to_string(),
+                    features,
+                    custom_records: std::collections::HashMap::new(),
+                }),
+                num_channels: 0,
+                total_capacity: 0,
+                channels: vec![],
+            })
+        });
+
+        let message_router = MessageRouter::new(mock_router, mock_client);
+
+        let secp_ctx = create_secp_ctx();
+
+        let sender_secret = SecretKey::from_slice(&[3; 32]).unwrap();
+        let sender = PublicKey::from_secret_key(&secp_ctx, &sender_secret);
+
+        let destination_secret = SecretKey::from_slice(&[4; 32]).unwrap();
+        let destination_node = PublicKey::from_secret_key(&secp_ctx, &destination_secret);
+        let destination = Destination::Node(destination_node);
+
+        let peers = vec![];
+
+        let result = message_router.find_path(sender, peers, destination);
+        assert!(result.is_ok());
+
+        let path = result.unwrap();
+        assert!(path.intermediate_nodes.is_empty());
+        assert!(path.first_node_addresses.is_some());
+
+        let addresses = path.first_node_addresses.unwrap();
+        assert_eq!(addresses.len(), 2);
+        assert!(addresses
+            .iter()
+            .any(|addr| addr.to_string() == "127.0.0.1:9735"));
+        // IPv6 addresses get expanded, so check for the expanded form
+        assert!(addresses
+            .iter()
+            .any(|addr| addr.to_string() == "[0000:0000:0000:0000:0000:0000:0000:0001]:9735"));
+    }
+}

--- a/src/offers/client_impls.rs
+++ b/src/offers/client_impls.rs
@@ -217,7 +217,10 @@ impl Bolt12InvoiceCreator for Client {
         let req = Invoice {
             memo: description,
             value_msat: amount,
-            expiry: 3600,
+            // We use a 24 hour expiry for invoices so blinded path restrictions have a higher CLTV
+            // expiry. This is a workaround for LDK default nodes that add a cltv offet
+            // for privacy reasons.
+            expiry: 60 * 60 * 24,
             is_blinded: true,
             ..Default::default()
         };

--- a/src/offers/client_impls.rs
+++ b/src/offers/client_impls.rs
@@ -1,9 +1,12 @@
 use lightning::blinded_path::payment::BlindedPaymentPath;
 use lightning::blinded_path::IntroductionNode;
+use lightning::offers::invoice_request::InvoiceRequest;
+use lightning::offers::offer::Amount;
 use log::error;
 use tonic::async_trait;
 use tonic_lnd::lnrpc::{
-    FeeLimit, GetInfoRequest, GetInfoResponse, HtlcAttempt, Payment, QueryRoutesResponse, Route,
+    AddInvoiceResponse, FeeLimit, GetInfoRequest, GetInfoResponse, HtlcAttempt, Invoice, PayReq,
+    PayReqString, Payment, QueryRoutesResponse, Route,
 };
 use tonic_lnd::routerrpc::TrackPaymentRequest;
 use tonic_lnd::tonic::Status;
@@ -14,7 +17,7 @@ use tonic_lnd::{
     Client,
 };
 
-use crate::lnd::{InvoicePayer, MessageSigner, OfferCreator, PeerConnector};
+use crate::lnd::{Bolt12InvoiceCreator, InvoicePayer, MessageSigner, OfferCreator, PeerConnector};
 
 use super::lnd_requests::get_node_id;
 use super::OfferError;
@@ -197,13 +200,48 @@ impl OfferCreator for LightningClient {
     }
 }
 
+#[async_trait]
+impl Bolt12InvoiceCreator for Client {
+    async fn add_invoice(
+        &mut self,
+        invoice_request: InvoiceRequest,
+    ) -> Result<AddInvoiceResponse, Status> {
+        let amount = match invoice_request.amount() {
+            Some(Amount::Bitcoin { amount_msats }) => amount_msats as i64,
+            _ => 0,
+        };
+        let description = match invoice_request.description() {
+            Some(description) => description.to_string(),
+            None => "".to_string(),
+        };
+        let req = Invoice {
+            memo: description,
+            value_msat: amount,
+            expiry: 3600,
+            is_blinded: true,
+            ..Default::default()
+        };
+        let resp = self.lightning().add_invoice(req).await?;
+        Ok(resp.into_inner())
+    }
+
+    async fn decode_payment_request(&mut self, payment_request: String) -> Result<PayReq, Status> {
+        let req = PayReqString {
+            pay_req: payment_request,
+        };
+        let resp = self.lightning().decode_pay_req(req).await?;
+        Ok(resp.into_inner())
+    }
+}
+
 #[cfg(test)]
 pub(super) mod tests {
     use super::*;
-    use crate::lnd::{InvoicePayer, PeerConnector};
-
+    use crate::lnd::{Bolt12InvoiceCreator, InvoicePayer, PeerConnector};
+    use lightning::offers::invoice_request::InvoiceRequest;
     use mockall::mock;
     use tonic::async_trait;
+    use tonic_lnd::lnrpc::{AddInvoiceResponse, PayReq};
     use tonic_lnd::lnrpc::{HtlcAttempt, NodeInfo, Route};
     use tonic_lnd::tonic::Status;
 
@@ -242,6 +280,16 @@ pub(super) mod tests {
             async fn list_peers(&mut self) -> Result<tonic_lnd::lnrpc::ListPeersResponse, Status>;
             async fn get_node_info(&mut self, pub_key: String, include_channels: bool) -> Result<NodeInfo, Status>;
             async fn connect_peer(&mut self, node_id: String, addr: String) -> Result<(), Status>;
+        }
+    }
+
+    mock! {
+        pub TestBolt12InvoiceCreator{}
+
+        #[async_trait]
+        impl Bolt12InvoiceCreator for TestBolt12InvoiceCreator {
+            async fn add_invoice(&mut self, invoice_request: InvoiceRequest) -> Result<AddInvoiceResponse, Status>;
+            async fn decode_payment_request(&mut self, payment_request: String) -> Result<PayReq, Status>;
         }
     }
 }

--- a/src/offers/handler.rs
+++ b/src/offers/handler.rs
@@ -8,6 +8,7 @@ use lightning::ln::channelmanager::{PaymentId, Verification};
 use lightning::ln::inbound_payment::ExpandedKey;
 use lightning::offers::invoice::Bolt12Invoice;
 use lightning::offers::invoice_error::InvoiceError;
+use lightning::offers::invoice_request::InvoiceRequest;
 use lightning::offers::nonce::Nonce;
 use lightning::offers::offer::{Offer, Quantity};
 use lightning::onion_message::messenger::{
@@ -25,7 +26,8 @@ use tonic_lnd::lnrpc::{FeeLimit, Payment};
 use tonic_lnd::Client;
 
 use super::lnd_requests::{
-    create_invoice_request, create_offer, get_node_id_from_scid, send_invoice_request,
+    create_invoice_info_from_request, create_invoice_request, create_offer, get_node_id_from_scid,
+    send_invoice_request, LndkBolt12InvoiceInfo,
 };
 use super::OfferError;
 use crate::offers::lnd_requests::{send_payment, track_payment, CreateOfferArgs};
@@ -323,6 +325,14 @@ impl OfferHandler {
         let args = CreateOfferArgs::from_params(&params);
         let client = params.client.lightning().clone();
         create_offer(client, args, &self.messenger_utils, &self.expanded_key).await
+    }
+
+    pub async fn create_invoice(
+        &self,
+        client: Client,
+        invoice_request: InvoiceRequest,
+    ) -> Result<LndkBolt12InvoiceInfo, OfferError> {
+        create_invoice_info_from_request(client, invoice_request).await
     }
 }
 

--- a/src/offers/lnd_requests.rs
+++ b/src/offers/lnd_requests.rs
@@ -1,4 +1,7 @@
-use std::str::FromStr;
+use std::{
+    str::FromStr,
+    time::{Duration, SystemTime},
+};
 
 use bitcoin::{key::Secp256k1, secp256k1::PublicKey, Network};
 use lightning::{
@@ -10,7 +13,11 @@ use lightning::{
         channelmanager::{PaymentId, Verification},
         inbound_payment::ExpandedKey,
     },
-    offers::{invoice_request::InvoiceRequest, offer::Offer},
+    offers::{
+        invoice_request::InvoiceRequest,
+        nonce::Nonce,
+        offer::{Offer, OfferBuilder, Quantity},
+    },
     onion_message::{
         messenger::{Destination, MessageSendInstructions},
         offers::OffersMessage,
@@ -24,8 +31,8 @@ use tonic_lnd::{
 };
 
 use crate::{
-    lnd::{features_support_onion_messages, InvoicePayer, PeerConnector},
-    offers::handler::SendPaymentParams,
+    lnd::{features_support_onion_messages, InvoicePayer, OfferCreator, PeerConnector},
+    offers::handler::{CreateOfferParams, SendPaymentParams},
     onion_messenger::MessengerUtilities,
 };
 
@@ -115,6 +122,79 @@ pub(super) async fn track_payment(
         .track_payment(payment_hash)
         .await
         .map_err(|_| OfferError::PaymentFailure)
+}
+
+pub(super) struct CreateOfferArgs {
+    amount_msats: u64,
+    chain: Network,
+    description: Option<String>,
+    issuer: Option<String>,
+    quantity: Option<Quantity>,
+    expiry: Option<Duration>,
+}
+
+impl CreateOfferArgs {
+    pub fn from_params(params: &CreateOfferParams) -> Self {
+        Self {
+            amount_msats: params.amount_msats,
+            chain: params.chain,
+            description: params.description.clone(),
+            issuer: params.issuer.clone(),
+            quantity: params.quantity,
+            expiry: params.expiry,
+        }
+    }
+}
+
+pub(super) async fn create_offer(
+    mut creator: (impl OfferCreator + std::marker::Send + 'static + PeerConnector),
+    args: CreateOfferArgs,
+    entropy_source: &MessengerUtilities,
+    expanded_key: &ExpandedKey,
+) -> Result<Offer, OfferError> {
+    let info = creator
+        .get_info()
+        .await
+        .map_err(|_| OfferError::NodeAddressNotFound)?;
+    let node_id =
+        PublicKey::from_str(&info.identity_pubkey).map_err(|_| OfferError::NodeAddressNotFound)?;
+    let nonce = Nonce::from_entropy_source(entropy_source);
+    let secp_ctx = Secp256k1::new();
+
+    let message_context = MessageContext::Offers(OffersContext::InvoiceRequest { nonce });
+    let path = create_reply_path(creator, node_id, message_context, entropy_source).await?;
+
+    let mut builder =
+        OfferBuilder::deriving_signing_pubkey(node_id, expanded_key, nonce, &secp_ctx)
+            .amount_msats(args.amount_msats)
+            .chain(args.chain)
+            .path(path);
+    builder = match args.description {
+        Some(description) => builder.description(description),
+        None => builder,
+    };
+    builder = match args.issuer {
+        Some(issuer) => builder.issuer(issuer),
+        None => builder,
+    };
+    builder = match args.quantity {
+        Some(quantity) => builder.supported_quantity(quantity),
+        None => builder,
+    };
+    builder = match args.expiry {
+        Some(expiry) => {
+            let expiry = SystemTime::now() + expiry;
+            let absolute_expiry = expiry
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map_err(|_| OfferError::CreateOfferTimeFailure)?;
+            builder.absolute_expiry(absolute_expiry)
+        }
+        None => builder,
+    };
+    let offer = builder
+        .build()
+        .map_err(|e| OfferError::CreateOfferFailure(e))?;
+    Ok(offer)
 }
 
 /// create_reply_path creates a blinded path to provide to the offer node when requesting an
@@ -322,7 +402,9 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
-    use crate::offers::client_impls::tests::{MockTestInvoicePayer, MockTestPeerConnector};
+    use crate::offers::client_impls::tests::{
+        MockTestInvoicePayer, MockTestOfferCreator, MockTestPeerConnector,
+    };
     use crate::offers::decode;
     use lightning::{
         blinded_path::payment::{
@@ -341,8 +423,8 @@ mod tests {
     use mockall::predicate::eq;
     use tonic_lnd::{
         lnrpc::{
-            ChannelEdge, HtlcAttempt, LightningNode, ListPeersResponse, NodeAddress, NodeInfo,
-            QueryRoutesResponse, Route,
+            ChannelEdge, GetInfoResponse, HtlcAttempt, LightningNode, ListPeersResponse,
+            NodeAddress, NodeInfo, QueryRoutesResponse, Route,
         },
         tonic::Status,
     };
@@ -874,5 +956,240 @@ mod tests {
             resp_1.unwrap().0.payer_signing_pubkey(),
             resp_2.unwrap().0.payer_signing_pubkey()
         );
+    }
+
+    // Helper function to create a mock for successful create_offer tests
+    fn setup_create_offer_success_mock() -> MockTestOfferCreator {
+        let mut creator_mock = MockTestOfferCreator::new();
+
+        // Mock get_info to return a valid response
+        creator_mock.expect_get_info().returning(|| {
+            Ok(GetInfoResponse {
+                identity_pubkey: get_pubkeys()[1].clone(),
+                ..Default::default()
+            })
+        });
+
+        creator_mock.expect_list_peers().returning(|| {
+            let peer = tonic_lnd::lnrpc::Peer {
+                pub_key: get_pubkeys()[0].clone(),
+                ..Default::default()
+            };
+            Ok(ListPeersResponse { peers: vec![peer] })
+        });
+
+        creator_mock
+    }
+
+    #[tokio::test]
+    async fn test_create_offer_success() {
+        let creator_mock = setup_create_offer_success_mock();
+
+        let entropy_source = MessengerUtilities::new([42; 32]);
+        let expanded_key = ExpandedKey::new([42; 32]);
+
+        let args = CreateOfferArgs {
+            amount_msats: 1000,
+            chain: Network::Regtest,
+            description: Some("Test offer".to_string()),
+            issuer: Some("Test issuer".to_string()),
+            quantity: Some(Quantity::One),
+            expiry: None,
+        };
+        let result = create_offer(creator_mock, args, &entropy_source, &expanded_key).await;
+
+        assert!(result.is_ok());
+        let offer = result.unwrap();
+
+        // Verify the offer properties
+        assert_eq!(
+            offer.amount().unwrap(),
+            Amount::Bitcoin { amount_msats: 1000 }
+        );
+        assert_eq!(offer.description().unwrap().to_string(), "Test offer");
+        assert_eq!(offer.issuer().unwrap().to_string(), "Test issuer");
+        assert_eq!(offer.supported_quantity(), Quantity::One);
+    }
+
+    #[tokio::test]
+    async fn test_create_offer_minimal() {
+        let creator_mock = setup_create_offer_success_mock();
+
+        let entropy_source = MessengerUtilities::new([42; 32]);
+        let expanded_key = ExpandedKey::new([42; 32]);
+
+        // Only provide required parameters
+        let args = CreateOfferArgs {
+            amount_msats: 1000,
+            chain: Network::Regtest,
+            description: None,
+            issuer: None,
+            quantity: None,
+            expiry: None,
+        };
+        let result = create_offer(creator_mock, args, &entropy_source, &expanded_key).await;
+
+        assert!(result.is_ok());
+        let offer = result.unwrap();
+
+        // Verify the offer has default values for optional parameters
+        assert_eq!(
+            offer.amount().unwrap(),
+            Amount::Bitcoin { amount_msats: 1000 }
+        );
+        assert_eq!(offer.description().unwrap().to_string(), ""); // Empty description
+        assert_eq!(offer.issuer(), None);
+        assert_eq!(offer.supported_quantity(), Quantity::One);
+    }
+
+    #[tokio::test]
+    async fn test_create_offer_with_expiry() {
+        let creator_mock = setup_create_offer_success_mock();
+
+        let entropy_source = MessengerUtilities::new([42; 32]);
+        let expanded_key = ExpandedKey::new([42; 32]);
+
+        // Include expiry parameter
+        let args = CreateOfferArgs {
+            amount_msats: 1000,
+            chain: Network::Regtest,
+            description: None,
+            issuer: None,
+            quantity: None,
+            expiry: Some(Duration::from_secs(3600)),
+        };
+        let result = create_offer(creator_mock, args, &entropy_source, &expanded_key).await;
+
+        assert!(result.is_ok());
+        let offer = result.unwrap();
+
+        // Verify the offer has an expiry set (not None)
+        assert!(offer.absolute_expiry().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_create_offer_get_info_error() {
+        let mut creator_mock = MockTestOfferCreator::new();
+
+        // Mock get_info to return an error
+        creator_mock
+            .expect_get_info()
+            .returning(|| Err(Status::internal("Failed to get node info")));
+
+        let entropy_source = MessengerUtilities::new([42; 32]);
+        let expanded_key = ExpandedKey::new([42; 32]);
+
+        let args = CreateOfferArgs {
+            amount_msats: 1000,
+            chain: Network::Regtest,
+            description: None,
+            issuer: None,
+            quantity: None,
+            expiry: None,
+        };
+        let result = create_offer(creator_mock, args, &entropy_source, &expanded_key).await;
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            OfferError::NodeAddressNotFound
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_create_offer_invalid_pubkey() {
+        let mut creator_mock = MockTestOfferCreator::new();
+
+        // Mock get_info to return an invalid pubkey
+        creator_mock.expect_get_info().returning(|| {
+            Ok(GetInfoResponse {
+                identity_pubkey: "invalid_pubkey".to_string(),
+                ..Default::default()
+            })
+        });
+
+        let entropy_source = MessengerUtilities::new([42; 32]);
+        let expanded_key = ExpandedKey::new([42; 32]);
+
+        let args = CreateOfferArgs {
+            amount_msats: 1000,
+            chain: Network::Regtest,
+            description: None,
+            issuer: None,
+            quantity: None,
+            expiry: None,
+        };
+        let result = create_offer(creator_mock, args, &entropy_source, &expanded_key).await;
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            OfferError::NodeAddressNotFound
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_create_offer_with_quantity() {
+        let creator_mock = setup_create_offer_success_mock();
+
+        let entropy_source = MessengerUtilities::new([42; 32]);
+        let expanded_key = ExpandedKey::new([42; 32]);
+
+        // Test with different quantity types
+        let args = CreateOfferArgs {
+            amount_msats: 1000,
+            chain: Network::Regtest,
+            description: None,
+            issuer: None,
+            quantity: Some(Quantity::Unbounded),
+            expiry: None,
+        };
+        let result = create_offer(creator_mock, args, &entropy_source, &expanded_key).await;
+
+        assert!(result.is_ok());
+        let offer = result.unwrap();
+
+        assert_eq!(offer.supported_quantity(), Quantity::Unbounded);
+    }
+
+    #[tokio::test]
+    async fn test_create_offer_different_signing_pubkeys_and_ids() {
+        let creator_mock1 = setup_create_offer_success_mock();
+        let creator_mock2 = setup_create_offer_success_mock();
+
+        let entropy_source = MessengerUtilities::new([42; 32]);
+        let expanded_key = ExpandedKey::new([42; 32]);
+
+        let args = CreateOfferArgs {
+            amount_msats: 1000,
+            chain: Network::Regtest,
+            description: None,
+            issuer: None,
+            quantity: None,
+            expiry: None,
+        };
+
+        let args2 = CreateOfferArgs {
+            amount_msats: 1000,
+            chain: Network::Regtest,
+            description: None,
+            issuer: None,
+            quantity: None,
+            expiry: None,
+        };
+
+        let offer1 = create_offer(creator_mock1, args, &entropy_source, &expanded_key).await;
+        let offer2 = create_offer(creator_mock2, args2, &entropy_source, &expanded_key).await;
+
+        assert!(offer1.is_ok());
+        assert!(offer2.is_ok());
+        let offer1 = offer1.unwrap();
+        let offer2 = offer2.unwrap();
+
+        assert_ne!(
+            offer1.issuer_signing_pubkey().unwrap(),
+            offer2.issuer_signing_pubkey().unwrap()
+        );
+        assert_ne!(offer1.id(), offer2.id());
     }
 }

--- a/src/offers/lnd_requests.rs
+++ b/src/offers/lnd_requests.rs
@@ -210,6 +210,7 @@ pub(super) async fn create_invoice_info_from_request(
     mut creator: impl Bolt12InvoiceCreator + std::marker::Send + 'static,
     invoice_request: InvoiceRequest,
 ) -> Result<LndkBolt12InvoiceInfo, OfferError> {
+    log::trace!("Creating invoice");
     let invoice_response = creator
         .add_invoice(invoice_request)
         .await
@@ -227,6 +228,7 @@ pub(super) async fn create_invoice_info_from_request(
 
     let payment_hash = PaymentHash(*payment_hash.as_byte_array());
 
+    log::trace!("Parsing blinded paths");
     let payment_paths = parse_blinded_paths(payreq.blinded_paths);
     Ok(LndkBolt12InvoiceInfo {
         payment_hash,

--- a/src/offers/mod.rs
+++ b/src/offers/mod.rs
@@ -50,6 +50,10 @@ pub enum OfferError {
     IntroductionNodeNotFound,
     /// Cannot fetch channel info.
     GetChannelInfo(Status),
+    /// Failed to create offer.
+    CreateOfferFailure(Bolt12SemanticError),
+    /// Failed to create offer with expiry time given system clock.
+    CreateOfferTimeFailure,
 }
 
 impl Display for OfferError {
@@ -79,6 +83,11 @@ impl Display for OfferError {
             OfferError::InvoiceTimeout(e) => write!(f, "Did not receive invoice in {e:?} seconds."),
             OfferError::IntroductionNodeNotFound => write!(f, "Could not find introduction node."),
             OfferError::GetChannelInfo(e) => write!(f, "Could not fetch channel info: {e:?}"),
+            OfferError::CreateOfferFailure(e) => write!(f, "Could not create offer: {e:?}"),
+            OfferError::CreateOfferTimeFailure => write!(
+                f,
+                "Could not create offer with expiry time given system clock"
+            ),
         }
     }
 }

--- a/src/offers/mod.rs
+++ b/src/offers/mod.rs
@@ -54,6 +54,12 @@ pub enum OfferError {
     CreateOfferFailure(Bolt12SemanticError),
     /// Failed to create offer with expiry time given system clock.
     CreateOfferTimeFailure,
+    /// Failed to add invoice.
+    AddInvoiceFailure(Status),
+    /// Failed to decode payment request.
+    DecodePaymentRequestFailure(Status),
+    /// Failed to parse payment hash.
+    ParsePaymentHashFailure(String),
 }
 
 impl Display for OfferError {
@@ -88,6 +94,15 @@ impl Display for OfferError {
                 f,
                 "Could not create offer with expiry time given system clock"
             ),
+            OfferError::AddInvoiceFailure(e) => {
+                write!(f, "Could not add invoice to lnd node: {e:?}")
+            }
+            OfferError::DecodePaymentRequestFailure(e) => {
+                write!(f, "Could not decode payment request: {e:?}")
+            }
+            OfferError::ParsePaymentHashFailure(e) => {
+                write!(f, "Could not parse payment hash: {e:?}")
+            }
         }
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -135,7 +135,7 @@ pub async fn connect_network(
 
     lnd.wait_for_chain_sync().await;
 
-    ldk2.open_channel(ldk1_pubkey, addr, 200_000, 10_000_000, false)
+    ldk2.open_channel(ldk1_pubkey, addr, 300_000, 100_000_000, false)
         .await
         .unwrap();
 
@@ -144,8 +144,8 @@ pub async fn connect_network(
     ldk2.open_channel(
         lnd_pubkey,
         SocketAddr::from_str(&lnd_network_addr).unwrap(),
-        200_000,
-        10_000_000,
+        300_000,
+        100_000_000,
         announce_channel,
     )
     .await

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,6 +8,7 @@ use chrono::Utc;
 use corepc_node::{get_available_port, Conf, ConnectParams, Node};
 use ldk_sample::config::LdkUserInfo;
 use ldk_sample::node_api::Node as LdkNode;
+use ldk_sample::HTLCStatus;
 use lightning::util::logger::Level;
 use lndk::lnd::validate_lnd_creds;
 use lndk::offers::handler::OfferHandler;
@@ -25,7 +26,7 @@ use tempfile::{tempdir, Builder, TempDir};
 use tokio::select;
 use tokio::time::Interval;
 use tokio::time::{sleep, timeout, Duration};
-use tonic_lnd::lnrpc::{AddressType, GetInfoRequest};
+use tonic_lnd::lnrpc::{AddressType, GetInfoRequest, InvoiceHtlcState, ListInvoiceRequest};
 use tonic_lnd::Client;
 
 const LNDK_TESTS_FOLDER: &str = "lndk-tests";
@@ -134,7 +135,7 @@ pub async fn connect_network(
 
     lnd.wait_for_chain_sync().await;
 
-    ldk2.open_channel(ldk1_pubkey, addr, 200000, 0, false)
+    ldk2.open_channel(ldk1_pubkey, addr, 200_000, 10_000_000, false)
         .await
         .unwrap();
 
@@ -143,8 +144,8 @@ pub async fn connect_network(
     ldk2.open_channel(
         lnd_pubkey,
         SocketAddr::from_str(&lnd_network_addr).unwrap(),
-        200000,
-        10000000,
+        200_000,
+        10_000_000,
         announce_channel,
     )
     .await
@@ -307,6 +308,76 @@ pub fn get_lnd_args(
     (args.to_vec(), stdout_file, stderr_file)
 }
 
+pub async fn wait_for_ldk_payment_completion(
+    ldk_node: &LdkNode,
+    timeout_duration: Duration,
+) -> Result<(), ()> {
+    log::info!("Waiting for payment to complete...");
+    let start_time = tokio::time::Instant::now();
+
+    loop {
+        if start_time.elapsed() > timeout_duration {
+            return Err(());
+        }
+
+        let payments = ldk_node.list_payments().await;
+
+        if let Some(latest_payment) = payments.last() {
+            log::debug!("Checking payment status: {:?}", latest_payment.status);
+            match latest_payment.status {
+                HTLCStatus::Pending => {
+                    log::debug!("Payment still pending, waiting 1 second...");
+                    sleep(Duration::from_secs(1)).await;
+                }
+                HTLCStatus::Succeeded => {
+                    log::info!("Payment succeeded");
+                    return Ok(());
+                }
+                HTLCStatus::Failed => {
+                    log::error!("Payment failed");
+                    return Err(());
+                }
+            }
+        } else {
+            log::debug!("No payments found yet, waiting 1 second...");
+            sleep(Duration::from_secs(1)).await;
+        }
+    }
+}
+
+pub async fn wait_for_lnd_payment_completion(
+    lnd_client: &mut Client,
+    timeout_duration: Duration,
+) -> Result<(), ()> {
+    log::info!("Waiting for payment to appear in lnd...");
+    let start_time = tokio::time::Instant::now();
+
+    loop {
+        if start_time.elapsed() > timeout_duration {
+            return Err(());
+        }
+
+        let invoices = lnd_client
+            .lightning()
+            .list_invoices(ListInvoiceRequest {
+                ..Default::default()
+            })
+            .await;
+        assert!(invoices.is_ok());
+        let invoices = invoices.unwrap().into_inner();
+        if !invoices.invoices.is_empty() {
+            let invoice = invoices.invoices[0].clone();
+            log::debug!("Invoice status: {:?}", invoice.state);
+            if invoice.state == InvoiceHtlcState::Settled as i32 {
+                log::info!("Payment succeeded");
+                return Ok(());
+            }
+        }
+        log::debug!("No payments found yet, waiting 1 second...");
+        sleep(Duration::from_secs(1)).await;
+    }
+}
+
 // BitcoindNode holds the tools we need to interact with a Bitcoind node.
 pub struct BitcoindNode {
     pub node: Node,
@@ -393,7 +464,6 @@ impl LndNode {
         let lnd_port = corepc_node::get_available_port().unwrap();
         let rpc_addr = format!("localhost:{}", port);
         let cert_path = lnd_dir.to_str().unwrap().to_string() + "/tls.cert";
-
         let (args, stdout_file, stderr_file) = get_lnd_args(
             &lnd_dir_binding,
             &bitcoind_connect_params,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -91,7 +91,8 @@ pub async fn setup_test_infrastructure(
 pub async fn connect_network(
     ldk1: &LdkNode,
     ldk2: &LdkNode,
-    announce_channel: bool,
+    announce_channel_ldk: bool,
+    announce_channel_lnd: bool,
     lnd: &mut LndNode,
     bitcoind: &BitcoindNode,
 ) -> (PublicKey, PublicKey, PublicKey) {
@@ -135,9 +136,15 @@ pub async fn connect_network(
 
     lnd.wait_for_chain_sync().await;
 
-    ldk2.open_channel(ldk1_pubkey, addr, 300_000, 100_000_000, false)
-        .await
-        .unwrap();
+    ldk2.open_channel(
+        ldk1_pubkey,
+        addr,
+        300_000,
+        100_000_000,
+        announce_channel_ldk,
+    )
+    .await
+    .unwrap();
 
     lnd.wait_for_graph_sync().await;
 
@@ -146,7 +153,7 @@ pub async fn connect_network(
         SocketAddr::from_str(&lnd_network_addr).unwrap(),
         300_000,
         100_000_000,
-        announce_channel,
+        announce_channel_lnd,
     )
     .await
     .unwrap();


### PR DESCRIPTION
This PR is on top of #216, and uses forked branch on top of v0.1.3 of rust lightning to expose already merged exposition of [`from_blinded_path_and_payinfo`](https://github.com/lightningdevkit/rust-lightning/pull/3807)  function.

This PR is _not ready_, sometimes `add_invoice` on LND's fails to build blinded paths and I left some _todos_ that I should tackle. I guess show early is better in these big features

**edit: this is fixed in 33b6fcb6452ac9b4dab8572c37316ba37ef8bc75**

Closes #170 (as mvp)

## Main implementation 
### Create offers dfdadde66e3c9e48e70cc772955ec3b6af00a3c0
Handle exposes a function that given the constant `ExpandedKey` (from #214) creates an offer with a single path using `create_reply_path`. Probably we should add more than one.

### Request Invoice and Invoice Generation

Whenever a `RequestInvoice` message arrives, we check that context `Nonce` is present and we verify that the request. Then, we create an invoice on LND's and we parse the `blinded_paths` and the `payment_hash` to be used to build a new Invoice. Finally we respond to the `RequestInvoice` with the externally built Bolt12Invoice with information to be used for an `InvoiceError` (we are not using that yet).

## Good to know
- LND fails to build `blinded_paths` with amount 0. [Link to issue](https://github.com/lightningnetwork/lnd/issues/9256). Tested on regtest with eclair and cln nodes around.
- We are not supporting `InvoiceErrors` for now as we should find a way of build outside of LDK the `blinding_path` for the response. If we use current `ldk` implementation we can not build it. This PR can be merged without it.

### Misc
Add CLI an gRPC server call to create offer. 
Added basic integration test on creating an offer and the flow of paying an Offer from LDK nodes.


## To do

- [x] Understand edge cases of creation of blinded_paths on LND side
- [x] Understand edge case of LDK-sample paying LND. Having issues on decoding the onion package.
- [x] Fix flaky integration test based on 👆🏼 
- [x] Fix Clippy / and some of the To do
- [x] Rebase on top refactor changes 💀 

### Follow ups

- Better peer selection for offers
- More Blinding paths on offers

### Notes
I tested on mainnet after the latest changes and rebase. It is currently working paying from Lexe, Phoenix and core-lightning
 