### PR TITLE
Implement `ConnectionNeeded`

### DIFF
--- a/src/offers/client_impls.rs
+++ b/src/offers/client_impls.rs
@@ -5,6 +5,7 @@ use tonic::async_trait;
 use tonic_lnd::lnrpc::{HtlcAttempt, Payment, QueryRoutesResponse, Route};
 use tonic_lnd::routerrpc::TrackPaymentRequest;
 use tonic_lnd::tonic::Status;
+use tonic_lnd::LightningClient;
 use tonic_lnd::{
     lnrpc::{ListPeersRequest, ListPeersResponse, NodeInfo},
     signrpc::{KeyLocator, SignMessageReq},
@@ -17,11 +18,10 @@ use super::lnd_requests::get_node_id;
 use super::OfferError;
 
 #[async_trait]
-impl PeerConnector for Client {
+impl PeerConnector for LightningClient {
     async fn list_peers(&mut self) -> Result<ListPeersResponse, Status> {
         let list_req = ListPeersRequest::default();
-        self.lightning()
-            .list_peers(list_req)
+        self.list_peers(list_req)
             .await
             .map(|resp| resp.into_inner())
     }
@@ -38,10 +38,7 @@ impl PeerConnector for Client {
             ..Default::default()
         };
 
-        self.lightning()
-            .connect_peer(connect_req.clone())
-            .await
-            .map(|_| ())
+        self.connect_peer(connect_req.clone()).await.map(|_| ())
     }
 
     async fn get_node_info(
@@ -54,10 +51,7 @@ impl PeerConnector for Client {
             include_channels,
         };
 
-        self.lightning()
-            .get_node_info(req)
-            .await
-            .map(|resp| resp.into_inner())
+        self.get_node_info(req).await.map(|resp| resp.into_inner())
     }
 }
 

--- a/src/offers/lnd_requests.rs
+++ b/src/offers/lnd_requests.rs
@@ -244,7 +244,7 @@ pub async fn send_invoice_request(
     Ok((contents, send_instructions))
 }
 
-async fn connect_to_peer(
+pub(crate) async fn connect_to_peer(
     mut connector: impl PeerConnector,
     node_id: PublicKey,
 ) -> Result<(), OfferError> {

--- a/src/offers/lnd_requests.rs
+++ b/src/offers/lnd_requests.rs
@@ -191,12 +191,14 @@ pub async fn send_invoice_request(
     // any intermediate nodes here. In the future we'll query for a full path to the
     // introduction node for better sender privacy.
     match destination {
-        Destination::Node(pubkey) => connect_to_peer(client.clone(), pubkey).await?,
+        Destination::Node(pubkey) => connect_to_peer(client.lightning().clone(), pubkey).await?,
         Destination::BlindedPath(ref path) => match path.introduction_node() {
-            IntroductionNode::NodeId(pubkey) => connect_to_peer(client.clone(), *pubkey).await?,
+            IntroductionNode::NodeId(pubkey) => {
+                connect_to_peer(client.lightning().clone(), *pubkey).await?
+            }
             IntroductionNode::DirectedShortChannelId(direction, scid) => {
                 let pubkey = get_node_id(client.clone(), *scid, *direction).await?;
-                connect_to_peer(client.clone(), pubkey).await?
+                connect_to_peer(client.lightning().clone(), pubkey).await?
             }
         },
     };
@@ -210,8 +212,13 @@ pub async fn send_invoice_request(
 
     let pubkey = PublicKey::from_str(&info.identity_pubkey).unwrap();
     let message_context = MessageContext::Offers(offer_context);
-    let reply_path =
-        create_reply_path(client.clone(), pubkey, message_context, messenger_utils).await?;
+    let reply_path = create_reply_path(
+        client.lightning().clone(),
+        pubkey,
+        message_context,
+        messenger_utils,
+    )
+    .await?;
 
     let reply_path_intro_node_id = match reply_path.introduction_node() {
         IntroductionNode::NodeId(pubkey) => pubkey.to_string(),

--- a/src/offers/mod.rs
+++ b/src/offers/mod.rs
@@ -11,6 +11,7 @@ pub mod handler;
 mod lnd_requests;
 mod parse;
 
+pub(crate) use lnd_requests::connect_to_peer;
 pub use lnd_requests::create_reply_path;
 pub use parse::{decode, get_destination, validate_amount};
 

--- a/src/onion_messenger.rs
+++ b/src/onion_messenger.rs
@@ -1,5 +1,6 @@
 use crate::clock::TokioClock;
-use crate::lnd::{features_support_onion_messages, ONION_MESSAGES_OPTIONAL};
+use crate::lnd::{features_support_onion_messages, PeerConnector, ONION_MESSAGES_OPTIONAL};
+use crate::offers::connect_to_peer;
 use crate::rate_limit::{RateLimiter, RateLimiterCfg, TokenLimiter};
 use crate::{LifecycleSignals, LndkOnionMessenger, LDK_LOGGER_NAME};
 use async_trait::async_trait;
@@ -9,6 +10,7 @@ use bitcoin::Network;
 use core::ops::Deref;
 use futures::executor::block_on;
 use lightning::blinded_path::NodeIdLookUp;
+use lightning::events::{Event, EventHandler, EventsProvider, ReplayEvent};
 use lightning::ln::msgs::{Init, OnionMessage, OnionMessageHandler};
 use lightning::onion_message::async_payments::AsyncPaymentsMessageHandler;
 use lightning::onion_message::dns_resolution::DNSResolverMessageHandler;
@@ -284,7 +286,8 @@ impl LndkOnionMessenger {
 
         // Spin up a ticker that polls at an interval for any outgoing messages so that we can pass
         // on outgoing messages to LND.
-        let interval = time::interval(MSG_POLL_INTERVAL);
+        let mut interval = time::interval(MSG_POLL_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         let (events_shutdown, events_listener) =
             (signals.shutdown.clone(), signals.listener.clone());
         set.spawn(async move {
@@ -311,11 +314,15 @@ impl LndkOnionMessenger {
         let mut message_sender = CustomMessenger {
             client: ln_client.clone(),
         };
+        let event_handler = LndkEventHandler {
+            lnd_client: ln_client.clone(),
+        };
         let consume_result = consume_messenger_events(
             onion_messenger,
             receiver,
             &mut message_sender,
             rate_limiter,
+            event_handler,
             network,
         )
         .await;
@@ -685,10 +692,11 @@ impl fmt::Display for MessengerEvents {
 /// consume_messenger_events receives a series of onion messaging related events and delivers them
 /// to the OnionMessenger provided, using the RateLimiter to limit resources consumed by each peer.
 async fn consume_messenger_events(
-    onion_messenger: impl OnionMessageHandler,
+    onion_messenger: impl OnionMessageHandler + EventsProvider,
     mut events: Receiver<MessengerEvents>,
     message_sender: &mut impl SendCustomMessage,
     rate_limiter: &mut impl RateLimiter,
+    event_handler: impl EventHandler,
     network: Network,
 ) -> Result<(), ConsumerError> {
     let chain_hash = ChainHash::using_genesis_block_const(network);
@@ -744,6 +752,8 @@ async fn consume_messenger_events(
                 onion_messenger.handle_onion_message(pubkey, &onion_message)
             }
             MessengerEvents::SendOutgoing => {
+                onion_messenger.process_pending_events(&event_handler);
+
                 for peer in rate_limiter.peers() {
                     if let Some(msg) = onion_messenger.next_onion_message_for_peer(peer) {
                         info!("Sending outgoing onion message to {peer}.");
@@ -850,12 +860,42 @@ async fn relay_outgoing_msg_event(
     }
 }
 
+struct LndkEventHandler<T: PeerConnector + Send + 'static + Clone> {
+    lnd_client: T,
+}
+
+impl<T: PeerConnector + Send + 'static + Clone> EventHandler for LndkEventHandler<T> {
+    fn handle_event(&self, event: Event) -> Result<(), ReplayEvent> {
+        match event {
+            Event::ConnectionNeeded {
+                node_id,
+                addresses: _,
+            } => {
+                debug!("ConnectionNeeded event received for node: {}", node_id);
+                let lnd_client = self.lnd_client.clone();
+
+                // TODO: we probably want to retry this connect_to_peer call if it fails
+                tokio::spawn(async move {
+                    if let Err(e) = connect_to_peer(lnd_client, node_id).await {
+                        error!("Failed to connect to peer: {}", e);
+                    }
+                });
+                Ok(())
+            }
+            Event::OnionMessageIntercepted { .. } => Ok(()),
+            Event::OnionMessagePeerConnected { .. } => Ok(()),
+            _ => Ok(()),
+        }
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::tests::test_utils::pubkey;
     use bitcoin::secp256k1::PublicKey;
     use bitcoin::Network;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
 
     use bytes::BufMut;
     use lightning::events::{EventHandler, EventsProvider};
@@ -907,6 +947,21 @@ mod tests {
             }
     }
 
+    mock! {
+        TestPeerConnector{}
+
+        impl Clone for TestPeerConnector {
+            fn clone(&self) -> Self;
+        }
+
+         #[async_trait]
+         impl PeerConnector for TestPeerConnector {
+             async fn list_peers(&mut self) -> Result<tonic_lnd::lnrpc::ListPeersResponse, Status>;
+             async fn get_node_info(&mut self, pub_key: String, include_channels: bool) -> Result<tonic_lnd::lnrpc::NodeInfo, Status>;
+             async fn connect_peer(&mut self, node_id: String, addr: String) -> Result<(), Status>;
+         }
+    }
+
     // Mockall can't automatically produce a mock for EventsProvider since mockall requires generic
     // parameters be 'static. See: https://docs.rs/mockall/latest/mockall/#generic-traits-and-structs. So we add the trait to our
     // mock manually here.
@@ -915,7 +970,6 @@ mod tests {
         where
             H::Target: EventHandler,
         {
-            todo!()
         }
     }
 
@@ -980,11 +1034,11 @@ mod tests {
 
         rate_limiter
             .expect_peers()
-            .returning(move || vec![pk_1.clone(), pk_2.clone()]);
+            .returning(move || vec![pk_1, pk_2]);
 
         // Set up our mock to return an onion message for pk_1, and no onion messages for pk_2.
         mock.expect_next_onion_message_for_peer()
-            .withf(move |actual_pk: &PublicKey| *actual_pk == pk_1.clone())
+            .withf(move |actual_pk: &PublicKey| *actual_pk == pk_1)
             .returning(|_| Some(onion_message()));
 
         mock.expect_next_onion_message_for_peer()
@@ -1051,6 +1105,9 @@ mod tests {
             receiver,
             &mut sender_mock,
             &mut rate_limiter,
+            LndkEventHandler {
+                lnd_client: MockTestPeerConnector::new(),
+            },
             Network::Regtest,
         )
         .await
@@ -1080,6 +1137,9 @@ mod tests {
             receiver,
             &mut sender_mock,
             &mut rate_limiter,
+            LndkEventHandler {
+                lnd_client: MockTestPeerConnector::new(),
+            },
             Network::Regtest,
         )
         .await
@@ -1101,10 +1161,166 @@ mod tests {
             receiver_done,
             &mut sender_mock,
             &mut rate_limiter,
+            LndkEventHandler {
+                lnd_client: MockTestPeerConnector::new()
+            },
             Network::Regtest,
         )
         .await
         .is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_lndk_event_handler_connection_needed() {
+        let mut connector_mock = MockTestPeerConnector::new();
+        let expected_node_id = pubkey(1);
+
+        // Use atomic flag to track completion
+        let completed = Arc::new(AtomicBool::new(false));
+        let completed_clone = completed.clone();
+
+        connector_mock.expect_clone().times(1).returning(move || {
+            let completed = completed_clone.clone();
+            let mut mock = MockTestPeerConnector::new();
+
+            mock.expect_list_peers()
+                .returning(|| Ok(tonic_lnd::lnrpc::ListPeersResponse { peers: vec![] }));
+
+            mock.expect_get_node_info().returning(|_, _| {
+                let node_addr = tonic_lnd::lnrpc::NodeAddress {
+                    network: String::from("regtest"),
+                    addr: String::from("127.0.0.1:9735"),
+                };
+                let node = tonic_lnd::lnrpc::LightningNode {
+                    addresses: vec![node_addr],
+                    ..Default::default()
+                };
+                Ok(tonic_lnd::lnrpc::NodeInfo {
+                    node: Some(node),
+                    ..Default::default()
+                })
+            });
+
+            mock.expect_connect_peer().times(1).returning(move |_, _| {
+                completed.store(true, Ordering::SeqCst);
+                Ok(())
+            });
+            mock
+        });
+
+        let handler = LndkEventHandler {
+            lnd_client: connector_mock,
+        };
+
+        let event = Event::ConnectionNeeded {
+            node_id: expected_node_id,
+            addresses: vec![],
+        };
+
+        let result = handler.handle_event(event);
+        assert!(result.is_ok());
+
+        // Wait for completion with timeout
+        for _ in 0..100 {
+            if completed.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        assert!(
+            completed.load(Ordering::SeqCst),
+            "Task should have completed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_lndk_event_handler_other_events() {
+        let connector_mock = MockTestPeerConnector::new();
+        let handler = LndkEventHandler {
+            lnd_client: connector_mock,
+        };
+
+        // Test that other events just return ok.
+        let events = vec![
+            Event::OnionMessageIntercepted {
+                peer_node_id: pubkey(1),
+                message: onion_message(),
+            },
+            Event::OnionMessagePeerConnected {
+                peer_node_id: pubkey(2),
+            },
+        ];
+
+        for event in events {
+            let result = handler.handle_event(event);
+            assert!(result.is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_lndk_event_handler_connection_failed() {
+        let mut connector_mock = MockTestPeerConnector::new();
+        let expected_node_id = pubkey(1);
+
+        // Use atomic flag to track completion
+        let completed = Arc::new(AtomicBool::new(false));
+        let completed_clone = completed.clone();
+
+        connector_mock.expect_clone().times(1).returning(move || {
+            let completed = completed_clone.clone();
+            let mut mock = MockTestPeerConnector::new();
+
+            mock.expect_list_peers()
+                .returning(|| Ok(tonic_lnd::lnrpc::ListPeersResponse { peers: vec![] }));
+
+            mock.expect_get_node_info().returning(|_, _| {
+                let node_addr = tonic_lnd::lnrpc::NodeAddress {
+                    network: String::from("regtest"),
+                    addr: String::from("127.0.0.1:9735"),
+                };
+                let node = tonic_lnd::lnrpc::LightningNode {
+                    addresses: vec![node_addr],
+                    ..Default::default()
+                };
+                Ok(tonic_lnd::lnrpc::NodeInfo {
+                    node: Some(node),
+                    ..Default::default()
+                })
+            });
+
+            mock.expect_connect_peer().times(1).returning(move |_, _| {
+                completed.store(true, Ordering::SeqCst);
+                Err(tonic_lnd::tonic::Status::unavailable("Connection failed"))
+            });
+            mock
+        });
+
+        let handler = LndkEventHandler {
+            lnd_client: connector_mock,
+        };
+
+        let event = Event::ConnectionNeeded {
+            node_id: expected_node_id,
+            addresses: vec![],
+        };
+
+        let result = handler.handle_event(event);
+        // Should return ok even if connection fails.
+        assert!(result.is_ok());
+
+        // Wait for completion with timeout
+        for _ in 0..100 {
+            if completed.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        assert!(
+            completed.load(Ordering::SeqCst),
+            "Task should have completed"
+        );
     }
 
     #[tokio::test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -484,13 +484,12 @@ async fn test_reply_path_unannounced_peers() {
     };
     let offer_context = MessageContext::Offers(offer_context);
     let messenger_utils = MessengerUtilities::new([42; 32]);
-
     // In the small network we produced above, the lnd node is only connected to ldk2, which has a
     // private channel and as such, is an unadvertised node. Because of that, create_reply_path
     // should not use ldk2 as an introduction node and should return a reply path directly to
     // itself.
     let reply_path = create_reply_path(
-        lnd.client.clone().unwrap(),
+        lnd.client.clone().unwrap().lightning().clone(),
         lnd_pubkey,
         offer_context,
         &messenger_utils,
@@ -533,7 +532,7 @@ async fn test_reply_path_announced_peers() {
     // create_reply_path produces a path of length two with ldk2 as the introduction node, as we
     // expected.
     let reply_path = create_reply_path(
-        lnd.client.clone().unwrap(),
+        lnd.client.clone().unwrap().lightning().clone(),
         lnd_pubkey,
         offer_context,
         &messenger_utils,


### PR DESCRIPTION
In order to know if we should or not connect to a `IntroductionNode` LDK sends an `Event::ConnectionNeeded` when the messenger does not have the peer in it's state.

This PR adds the ConnectionNeeded spawning a `connect_to_peer` whenever is triggered. After this PR we should have all tools to finish #217 