### PR TITLE
Add fees limits args in pay_invoice and pay_offer cli commands

### DIFF
--- a/proto/lndkrpc.proto
+++ b/proto/lndkrpc.proto
@@ -13,6 +13,8 @@ message PayOfferRequest {
    optional uint64 amount = 2;
    optional string payer_note = 3;
    optional uint32 response_invoice_timeout = 4;
+   optional uint32 fee_limit = 5;
+   optional uint32 fee_limit_percent = 6;
 }
 
 message PayOfferResponse {
@@ -38,6 +40,8 @@ message GetInvoiceResponse {
 message PayInvoiceRequest {
     string invoice = 1;
     optional uint64 amount = 2;
+    optional uint32 fee_limit = 3;
+    optional uint32 fee_limit_percent = 4;
 }
 
 message PayInvoiceResponse {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -549,4 +549,42 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_fee_args_conflict_validation() {
+        let result = Cli::try_parse_from([
+            "lndk-cli",
+            "pay-offer",
+            "lno1qcp4256ypq",
+            "--fee-limit",
+            "1000",
+            "--fee-limit-percent",
+            "1",
+        ]);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_fee_args_single_validation() {
+        let result = Cli::try_parse_from([
+            "lndk-cli",
+            "pay-offer",
+            "lno1qcp4256ypq",
+            "--fee-limit",
+            "1000",
+        ]);
+
+        assert!(result.is_ok());
+
+        let result = Cli::try_parse_from([
+            "lndk-cli",
+            "pay-offer",
+            "lno1qcp4256ypq",
+            "--fee-limit-percent",
+            "1.0",
+        ]);
+
+        assert!(result.is_err());
+    }
 }

--- a/src/lnd.rs
+++ b/src/lnd.rs
@@ -21,7 +21,8 @@ use std::fmt::Display;
 use std::path::PathBuf;
 use std::{fmt, fs};
 use tonic_lnd::lnrpc::{
-    GetInfoResponse, HtlcAttempt, ListPeersResponse, NodeInfo, Payment, QueryRoutesResponse, Route,
+    FeeLimit, GetInfoResponse, HtlcAttempt, ListPeersResponse, NodeInfo, Payment,
+    QueryRoutesResponse, Route,
 };
 use tonic_lnd::signrpc::KeyLocator;
 use tonic_lnd::tonic::Status;
@@ -448,6 +449,7 @@ pub trait InvoicePayer {
         fee_base_msat: u32,
         fee_ppm: u32,
         msats: u64,
+        fee_limit: Option<FeeLimit>,
     ) -> Result<QueryRoutesResponse, Status>;
     async fn send_to_route(
         &mut self,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -59,6 +59,7 @@ async fn get_invoice_with_retry(
                 destination: destination.clone(),
                 reply_path: None,
                 response_invoice_timeout: Some(15),
+                fee_limit: None,
             })
             .await
             .map_err(|_| lndk::offers::OfferError::InvoiceTimeout(15));
@@ -103,6 +104,7 @@ async fn create_offers(
             destination: Destination::BlindedPath(blinded_path),
             reply_path: None,
             response_invoice_timeout: None,
+            fee_limit: None,
         };
 
         pay_cfgs.push(pay_cfg);
@@ -357,6 +359,7 @@ async fn test_lndk_pay_offer() {
         destination: Destination::BlindedPath(blinded_path.clone()),
         reply_path: None,
         response_invoice_timeout: None,
+        fee_limit: None,
     };
     select! {
         val = messenger.run(lndk_cfg.clone(), Arc::clone(&handler)) => {
@@ -409,6 +412,7 @@ async fn test_lndk_pay_offer_concurrently() {
         destination: Destination::BlindedPath(blinded_path.clone()),
         reply_path: None,
         response_invoice_timeout: None,
+        fee_limit: None,
     };
     // Let's also try to pay the same offer multiple times concurrently.
     select! {


### PR DESCRIPTION
Addresses issue #188 by enabling users to set custom fee limits when paying offers and invoices using the pay-offer and pay-invoice commands.

```bash
# Pay offer with custom fee limits
lndk-cli pay-offer lno1... --fee-limit 1000
lndk-cli pay-offer lno1... --fee-limit-percent 20


# Pay invoice with custom fee limits
lndk-cli pay-invoice <hex> --fee-limit 1000
lndk-cli pay-invoice <hex> --fee-limit-percent 20

```