### PR TITLE
Add retry intents on connect to peer

### DIFF
--- a/src/offers/client_impls.rs
+++ b/src/offers/client_impls.rs
@@ -255,6 +255,10 @@ pub(super) mod tests {
     mock! {
         pub TestPeerConnector{}
 
+        impl Clone for TestPeerConnector {
+            fn clone(&self) -> Self;
+        }
+
          #[async_trait]
          impl PeerConnector for TestPeerConnector {
              async fn list_peers(&mut self) -> Result<tonic_lnd::lnrpc::ListPeersResponse, Status>;

--- a/src/offers/mod.rs
+++ b/src/offers/mod.rs
@@ -14,7 +14,7 @@ pub mod handler;
 mod lnd_requests;
 mod parse;
 
-pub(crate) use lnd_requests::connect_to_peer;
+pub(crate) use lnd_requests::connect_to_peer_with_retry;
 pub use lnd_requests::create_reply_path;
 pub use parse::{decode, get_destination, validate_amount};
 


### PR DESCRIPTION
fixes #224 
If the connect_to_peer task fails somehow, it won't retry the connection probably missing the connection to the peer. Therefore, this commit adds a loop to the connectio_to_peer with retries.