### PR TITLE
multi: add logs when tracking payments

### DIFF
--- a/src/offers/client_impls.rs
+++ b/src/offers/client_impls.rs
@@ -2,7 +2,7 @@ use lightning::blinded_path::payment::BlindedPaymentPath;
 use lightning::blinded_path::IntroductionNode;
 use lightning::offers::invoice_request::InvoiceRequest;
 use lightning::offers::offer::Amount;
-use log::error;
+use log::{error, trace};
 use tonic::async_trait;
 use tonic_lnd::lnrpc::{
     AddInvoiceResponse, FeeLimit, GetInfoRequest, GetInfoResponse, HtlcAttempt, Invoice, PayReq,
@@ -184,6 +184,10 @@ impl InvoicePayer for Client {
             } else if payment.status() == tonic_lnd::lnrpc::payment::PaymentStatus::Failed {
                 return Err(OfferError::PaymentFailure);
             } else {
+                trace!(
+                    "Payment with preimage {} has not settled.",
+                    payment.payment_preimage,
+                );
                 continue;
             }
         }

--- a/src/offers/handler.rs
+++ b/src/offers/handler.rs
@@ -398,7 +398,7 @@ impl OffersMessageHandler for OfferHandler {
                             return None;
                         }
                     };
-                log::trace!("Invoice created: {:?}", invoice_info);
+                log::trace!("Invoice created successfully created...");
 
                 let invoice_builder = match verfied_invoice.respond_using_derived_keys(
                     invoice_info.payment_paths,

--- a/src/offers/lnd_requests.rs
+++ b/src/offers/lnd_requests.rs
@@ -117,11 +117,22 @@ pub(crate) async fn send_payment(
         .await
         .map_err(OfferError::RouteFailure)?;
 
-    let _ = payer
+    trace!("Routes found {}...", resp.routes.len());
+    let resp = payer
         .send_to_route(params.payment_hash, resp.routes[0].clone())
         .await
         .map_err(OfferError::RouteFailure)?;
 
+    trace!(
+        "Sent payment using preimage {} using attempt_id {} with status {}. {}",
+        hex::encode(resp.preimage),
+        resp.attempt_id,
+        resp.status,
+        resp.failure.map_or("".to_string(), |f| format!(
+            "failed with reason: {}.",
+            f.code
+        ))
+    );
     Ok(())
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -116,7 +116,10 @@ impl Offers for LNDKServer {
 
         let payment = match self.offer_handler.pay_offer(cfg).await {
             Ok(payment) => {
-                log::info!("Payment succeeded.");
+                log::info!(
+                    "Payment succeeded with preimage {}.",
+                    payment.payment_preimage
+                );
                 payment
             }
             Err(e) => match e {
@@ -204,7 +207,7 @@ impl Offers for LNDKServer {
 
         let (invoice, _, payment_id) = match self.offer_handler.get_invoice(cfg).await {
             Ok(invoice) => {
-                log::info!("Invoice request succeeded.");
+                log::info!("Invoice request succeeded for payment_id {}.", invoice.2);
                 invoice
             }
             Err(e) => match e {


### PR DESCRIPTION
Add logs when tracking payment, use pre image as identification of which payment is related.
Should close #233 