### PR TITLE
Improve CLI error messages

### DIFF
--- a/src/lnd.rs
+++ b/src/lnd.rs
@@ -373,7 +373,7 @@ pub enum LndError {
     /// LND node is not connected to bitcoin network.
     NetworkNotConnected,
     /// LND service is unavailable or not responding.
-    ServiceUnavailable(LndStatus),
+    ServiceUnavailable(String),
 }
 
 impl LndError {

--- a/src/offers/client_impls.rs
+++ b/src/offers/client_impls.rs
@@ -189,11 +189,15 @@ impl InvoicePayer for Client {
             .router()
             .track_payment_v2(req)
             .await
-            .map_err(OfferError::TrackFailure)?
+            .map_err(|e| OfferError::TrackFailure(e.message().to_string()))?
             .into_inner();
 
         // Wait for a failed or successful payment.
-        while let Some(payment) = stream.message().await.map_err(OfferError::TrackFailure)? {
+        while let Some(payment) = stream
+            .message()
+            .await
+            .map_err(|e| OfferError::TrackFailure(e.message().to_string()))?
+        {
             if payment.status() == tonic_lnd::lnrpc::payment::PaymentStatus::Succeeded {
                 return Ok(payment);
             } else if payment.status() == tonic_lnd::lnrpc::payment::PaymentStatus::Failed {

--- a/src/offers/mod.rs
+++ b/src/offers/mod.rs
@@ -12,7 +12,7 @@ use tonic_types::{ErrorDetails, StatusExt};
 mod client_impls;
 pub mod handler;
 mod lnd_requests;
-mod parse;
+pub mod parse;
 
 pub(crate) use lnd_requests::connect_to_peer_with_retry;
 pub use lnd_requests::create_reply_path_for_offer_creation;
@@ -131,53 +131,44 @@ impl Display for OfferError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             OfferError::AlreadyProcessing(id) => {
-                write!(
-                    f,
-                    "We're already trying to pay for a payment with this id {id}"
-                )
+                write!(f, "Payment with id {id} already in progress")
             }
-            OfferError::BuildUIRFailure(e) => write!(f, "Error building invoice request: {e:?}"),
-            OfferError::SignError(e) => write!(f, "Error signing invoice request: {e:?}"),
-            OfferError::DeriveKeyFailure(e) => write!(f, "Error signing invoice request: {e:?}"),
-            OfferError::InvalidAmount(e) => write!(f, "User provided an invalid amount: {e:?}"),
-            OfferError::InvalidCurrency => write!(
-                f,
-                "LNDK doesn't yet support offer currencies other than bitcoin"
-            ),
-            OfferError::PeerConnectError(e) => write!(f, "Error connecting to peer: {e:?}"),
-            OfferError::NodeAddressNotFound => write!(f, "Couldn't get node address"),
-            OfferError::ListPeersFailure(e) => write!(f, "Error listing peers: {e:?}"),
-            OfferError::BuildBlindedPathFailure => write!(f, "Error building blinded path"),
-            OfferError::RouteFailure(e) => write!(f, "Error routing payment: {e:?}"),
-            OfferError::TrackFailure(e) => write!(f, "Error tracking payment: {e:?}"),
-            OfferError::PaymentFailure => write!(f, "Failed to send payment"),
-            OfferError::InvoiceTimeout(e) => write!(f, "Did not receive invoice in {e:?} seconds."),
-            OfferError::IntroductionNodeNotFound => write!(f, "Could not find introduction node."),
-            OfferError::GetChannelInfo(e) => write!(f, "Could not fetch channel info: {e:?}"),
-            OfferError::CreateOfferFailure(e) => write!(f, "Could not create offer: {e:?}"),
-            OfferError::CreateOfferTimeFailure => write!(
-                f,
-                "Could not create offer with expiry time given system clock"
-            ),
+            OfferError::BuildUIRFailure(e) => write!(f, "Failed to build invoice request: {e:?}"),
+            OfferError::SignError(e) => write!(f, "Failed to sign invoice request: {e:?}"),
+            OfferError::DeriveKeyFailure(e) => write!(f, "Failed to derive key: {e:?}"),
+            OfferError::InvalidAmount(e) => write!(f, "Invalid amount: {e:?}"),
+            OfferError::InvalidCurrency => write!(f, "Only bitcoin currency is supported"),
+            OfferError::PeerConnectError(e) => write!(f, "Failed to connect to peer: {e:?}"),
+            OfferError::NodeAddressNotFound => write!(f, "Node address not found"),
+            OfferError::ListPeersFailure(e) => write!(f, "Failed to list peers: {e:?}"),
+            OfferError::BuildBlindedPathFailure => write!(f, "Failed to build blinded path"),
+            OfferError::RouteFailure(e) => write!(f, "Failed to route payment: {e:?}"),
+            OfferError::TrackFailure(e) => write!(f, "Failed to track payment: {e:?}"),
+            OfferError::PaymentFailure => write!(f, "Payment failed"),
+            OfferError::InvoiceTimeout(e) => {
+                write!(f, "Invoice request timed out after {e:?} seconds")
+            }
+            OfferError::IntroductionNodeNotFound => write!(f, "Introduction node not found"),
+            OfferError::GetChannelInfo(e) => write!(f, "Failed to get channel info: {e:?}"),
+            OfferError::CreateOfferFailure(e) => write!(f, "Failed to create offer: {e:?}"),
+            OfferError::CreateOfferTimeFailure => write!(f, "Invalid offer expiry time"),
             OfferError::AddInvoiceFailure(e) => {
-                write!(f, "Could not add invoice to lnd node: {e:?}")
+                write!(f, "Failed to add invoice to lnd node: {e:?}")
             }
             OfferError::DecodePaymentRequestFailure(e) => {
-                write!(f, "Could not decode payment request: {e:?}")
+                write!(f, "Failed to decode payment request: {e:?}")
             }
             OfferError::ParsePaymentHashFailure(e) => {
-                write!(f, "Could not parse payment hash: {e:?}")
+                write!(f, "Failed to parse payment hash: {e:?}")
             }
             OfferError::ParseOfferFailure(e) => {
-                write!(f, "The provided offer was invalid. Please provide a valid offer in bech32 format, i.e. starting with 'lno'. Error: {e:?}")
+                write!(f, "Invalid offer: must start with 'lno'. Error: {e:?}")
             }
             OfferError::ParseInvoiceFailure(e) => {
-                write!(f, "The provided invoice was invalid. Please provide a valid invoice in hex format. Error: {e:?}")
-            }
-            OfferError::EncodeInvoiceFailure(e) => {
-                write!(f, "Failed to encode invoice to hex format. Error: {e:?}")
+                write!(f, "Invalid invoice: must be hex format. Error: {e:?}")
             }
             OfferError::ListChannelsFailure(e) => write!(f, "Error listing channels: {e:?}"),
+            OfferError::EncodeInvoiceFailure(e) => write!(f, "Failed to encode invoice: {e:?}"),
         }
     }
 }

--- a/src/offers/mod.rs
+++ b/src/offers/mod.rs
@@ -6,7 +6,6 @@ use lightning::{
     offers::{merkle::SignError, parse::Bolt12ParseError, parse::Bolt12SemanticError},
 };
 use tonic::{Code, Status};
-use tonic_lnd::tonic::Status as LndStatus;
 use tonic_types::{ErrorDetails, StatusExt};
 
 mod client_impls;
@@ -29,23 +28,23 @@ pub enum OfferError {
     /// SignError indicates a failure to sign the invoice request.
     SignError(SignError),
     /// DeriveKeyFailure indicates a failure to derive key for signing the invoice request.
-    DeriveKeyFailure(LndStatus),
+    DeriveKeyFailure(String),
     /// User provided an invalid amount.
     InvalidAmount(String),
     /// Invalid currency contained in the offer.
     InvalidCurrency,
     /// Unable to connect to peer.
-    PeerConnectError(LndStatus),
+    PeerConnectError(String),
     /// No node address.
     NodeAddressNotFound,
     /// Cannot list peers.
-    ListPeersFailure(LndStatus),
+    ListPeersFailure(String),
     /// Failure to build a reply path.
     BuildBlindedPathFailure,
     /// Unable to find or send to payment route.
-    RouteFailure(LndStatus),
+    RouteFailure(String),
     /// Failed to track payment.
-    TrackFailure(LndStatus),
+    TrackFailure(String),
     /// Failed to send payment.
     PaymentFailure,
     /// Failed to receive an invoice back from offer creator before the timeout.
@@ -53,15 +52,15 @@ pub enum OfferError {
     /// Failed to find introduction node for blinded path.
     IntroductionNodeNotFound,
     /// Cannot fetch channel info.
-    GetChannelInfo(LndStatus),
+    GetChannelInfo(String),
     /// Failed to create offer.
     CreateOfferFailure(Bolt12SemanticError),
     /// Failed to create offer with expiry time given system clock.
     CreateOfferTimeFailure,
     /// Failed to add invoice.
-    AddInvoiceFailure(LndStatus),
+    AddInvoiceFailure(String),
     /// Failed to decode payment request.
-    DecodePaymentRequestFailure(LndStatus),
+    DecodePaymentRequestFailure(String),
     /// Failed to parse payment hash.
     ParsePaymentHashFailure(String),
     /// Failed to parse offer.
@@ -71,7 +70,7 @@ pub enum OfferError {
     /// Failed to encode invoice.
     EncodeInvoiceFailure(BitcoinIoError),
     /// Cannot list channels.
-    ListChannelsFailure(LndStatus),
+    ListChannelsFailure(String),
 }
 
 impl OfferError {
@@ -135,28 +134,28 @@ impl Display for OfferError {
             }
             OfferError::BuildUIRFailure(e) => write!(f, "Failed to build invoice request: {e:?}"),
             OfferError::SignError(e) => write!(f, "Failed to sign invoice request: {e:?}"),
-            OfferError::DeriveKeyFailure(e) => write!(f, "Failed to derive key: {e:?}"),
-            OfferError::InvalidAmount(e) => write!(f, "Invalid amount: {e:?}"),
+            OfferError::DeriveKeyFailure(e) => write!(f, "Failed to derive key: {e}"),
+            OfferError::InvalidAmount(e) => write!(f, "Invalid amount: {e}"),
             OfferError::InvalidCurrency => write!(f, "Only bitcoin currency is supported"),
-            OfferError::PeerConnectError(e) => write!(f, "Failed to connect to peer: {e:?}"),
+            OfferError::PeerConnectError(e) => write!(f, "Failed to connect to peer: {e}"),
             OfferError::NodeAddressNotFound => write!(f, "Node address not found"),
-            OfferError::ListPeersFailure(e) => write!(f, "Failed to list peers: {e:?}"),
+            OfferError::ListPeersFailure(e) => write!(f, "Failed to list peers: {e}"),
             OfferError::BuildBlindedPathFailure => write!(f, "Failed to build blinded path"),
-            OfferError::RouteFailure(e) => write!(f, "Failed to route payment: {e:?}"),
-            OfferError::TrackFailure(e) => write!(f, "Failed to track payment: {e:?}"),
+            OfferError::RouteFailure(e) => write!(f, "Failed to route payment: {e}"),
+            OfferError::TrackFailure(e) => write!(f, "Failed to track payment: {e}"),
             OfferError::PaymentFailure => write!(f, "Payment failed"),
             OfferError::InvoiceTimeout(e) => {
-                write!(f, "Invoice request timed out after {e:?} seconds")
+                write!(f, "Invoice request timed out after {e} seconds")
             }
             OfferError::IntroductionNodeNotFound => write!(f, "Introduction node not found"),
-            OfferError::GetChannelInfo(e) => write!(f, "Failed to get channel info: {e:?}"),
+            OfferError::GetChannelInfo(e) => write!(f, "Failed to get channel info: {e}"),
             OfferError::CreateOfferFailure(e) => write!(f, "Failed to create offer: {e:?}"),
             OfferError::CreateOfferTimeFailure => write!(f, "Invalid offer expiry time"),
             OfferError::AddInvoiceFailure(e) => {
-                write!(f, "Failed to add invoice to lnd node: {e:?}")
+                write!(f, "Failed to add invoice to lnd node: {e}")
             }
             OfferError::DecodePaymentRequestFailure(e) => {
-                write!(f, "Failed to decode payment request: {e:?}")
+                write!(f, "Failed to decode payment request: {e}")
             }
             OfferError::ParsePaymentHashFailure(e) => {
                 write!(f, "Failed to parse payment hash: {e:?}")

--- a/src/offers/parse.rs
+++ b/src/offers/parse.rs
@@ -1,16 +1,14 @@
 use lightning::{
-    offers::{
-        offer::{Amount, Offer},
-        parse::Bolt12ParseError,
-    },
+    offers::offer::{Amount, Offer},
     onion_message::messenger::Destination,
 };
+use std::str::FromStr;
 
 use super::OfferError;
 
 /// Decodes a bech32 offer string into an LDK offer.
-pub fn decode(offer_str: String) -> Result<Offer, Bolt12ParseError> {
-    offer_str.parse::<Offer>()
+pub fn decode(offer_str: String) -> Result<Offer, OfferError> {
+    Offer::from_str(&offer_str).map_err(OfferError::ParseOfferFailure)
 }
 
 /// Get the destination of an offer.

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,6 +2,7 @@ use crate::lnd::{get_lnd_client, get_network, Creds, LndCfg, LndError};
 use crate::lndkrpc::{CreateOfferRequest, CreateOfferResponse};
 use crate::offers::get_destination;
 use crate::offers::handler::{CreateOfferParams, PayOfferParams};
+use crate::offers::parse::decode;
 use crate::offers::validate_amount;
 use crate::offers::OfferError;
 use crate::{lndkrpc, Bolt12InvoiceString, OfferHandler};
@@ -10,7 +11,7 @@ use lightning::blinded_path::payment::BlindedPaymentPath;
 use lightning::blinded_path::{Direction, IntroductionNode};
 use lightning::ln::channelmanager::PaymentId;
 use lightning::offers::invoice::Bolt12Invoice;
-use lightning::offers::offer::{Offer, Quantity};
+use lightning::offers::offer::Quantity;
 use lightning::sign::EntropySource;
 use lightning::util::ser::Writeable;
 use lndkrpc::offers_server::Offers;
@@ -71,7 +72,7 @@ impl Offers for LNDKServer {
         let mut client = get_lnd_client(lnd_cfg)?;
 
         let inner_request = request.get_ref();
-        let offer = Offer::from_str(&inner_request.offer).map_err(OfferError::ParseOfferFailure)?;
+        let offer = decode(inner_request.offer.clone())?;
 
         let destination = get_destination(&offer).await?;
         let reply_path = None;
@@ -139,7 +140,7 @@ impl Offers for LNDKServer {
         let mut client = get_lnd_client(lnd_cfg)?;
 
         let inner_request = request.get_ref();
-        let offer = Offer::from_str(&inner_request.offer).map_err(OfferError::ParseOfferFailure)?;
+        let offer = decode(inner_request.offer.clone())?;
 
         let destination = get_destination(&offer).await?;
         let reply_path = None;

--- a/src/server.rs
+++ b/src/server.rs
@@ -80,7 +80,7 @@ impl Offers for LNDKServer {
             .lightning()
             .get_info(GetInfoRequest {})
             .await
-            .map_err(LndError::ServiceUnavailable)?
+            .map_err(|e| LndError::ServiceUnavailable(e.message().to_string()))?
             .into_inner();
         let network = get_network(info).await?;
 
@@ -149,7 +149,7 @@ impl Offers for LNDKServer {
             .lightning()
             .get_info(GetInfoRequest {})
             .await
-            .map_err(LndError::ServiceUnavailable)?
+            .map_err(|e| LndError::ServiceUnavailable(e.message().to_string()))?
             .into_inner();
         let network = get_network(info).await?;
 
@@ -239,7 +239,7 @@ impl Offers for LNDKServer {
             .lightning()
             .get_info(GetInfoRequest {})
             .await
-            .map_err(LndError::ServiceUnavailable)?
+            .map_err(|e| LndError::ServiceUnavailable(e.message().to_string()))?
             .into_inner();
         let network = get_network(info).await?;
         let quantity = parse_quantity(inner_request.quantity);


### PR DESCRIPTION
## Description
This PR is for https://github.com/lndk-org/lndk/issues/232. Standardize CLI error responses using machine codes from rpc details and Error enums.

---

### Changes
- Use machine error codes from error enums in cli error respones
- Standardize CLI and grpc error messages.
- Refactor cli file. 

### Considerations
- There are still some nested Status (for eg. `PeerConnectError(LndStatus)`) that still shows json inner Lnd error Status, maybe we could just pack the LndStatus message.
`ERROR (PEER_CONNECT_ERROR): Failed to connect to peer: Status { code: NotFound, message: "unable to find node", metadata: MetadataMap { headers: {"content-type": "application/grpc"} }, source: None }`
- I am not sure if it is a problem to modify the error messages

**EDIT:**
I remove nested LndStatus from errors and simplify it to just add the message of it in the errors