### PR TITLE
chore: update protobuf version on ci release

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -26,7 +26,7 @@ protobuf = { version = "27.3_1" }
 
 # Release dependencies for Linux
 [dist.dependencies.apt]
-protobuf-compiler = { version = "3.21.12-8.2build1" }
+protobuf-compiler = { version = "3.21.12-8.2ubuntu0.2" }
 
 # Use more recent version of ubuntu
 [dist.github-custom-runners]


### PR DESCRIPTION
fixes failed release on protobuf compiler issue.