### PR TITLE
refactor: require named arguments for CreateOffer CLI options

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -179,20 +179,20 @@ enum Commands {
     /// CreateOffer creates a BOLT 12 offer.
     CreateOffer {
         /// The amount of the offer in millisatoshis.
-        #[arg(required = false)]
+        #[arg(long, required = false)]
         amount: Option<u64>,
         /// The description of the offer.
-        #[arg(required = false)]
+        #[arg(long, required = false)]
         description: Option<String>,
         /// The issuer of the offer.
-        #[arg(required = false)]
+        #[arg(long, required = false)]
         issuer: Option<String>,
         /// Relative expiry of the offer in seconds.
-        #[arg(required = false)]
+        #[arg(long, required = false)]
         expiry: Option<u64>,
         /// The quantity of the offer. If 0, unbounded quantity is assumed. If None,
         /// quantity defaults to 1.
-        #[arg(required = false)]
+        #[arg(long, required = false)]
         quantity: Option<u64>,
     },
 }


### PR DESCRIPTION
Change all CreateOffer command arguments to use long-form flags (--amount, --description, --issuer, --expiry, --quantity) instead of positional arguments. This is needed otherwise you cannot for example create an offer with a quantity of Some(0), without having to specify all the other arguments because they were positional.